### PR TITLE
Add responsive mobile drawer menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,11 +10,26 @@
 <header class="bg-gray-800 sticky top-0 w-full z-50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6">
+    <nav class="space-x-6 hidden md:block">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-yellow-400">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
-  </div>
-</header>
+    <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+      </svg>
+    </button>
+    </div>
+    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-40 flex flex-col items-center justify-center space-y-6 text-xl transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      <a href="services.html" class="hover:text-yellow-400">Services</a>
+      <a href="locations.html" class="hover:text-yellow-400">Locations</a>
+      <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>
+      <a href="about.html" class="hover:text-yellow-400">About</a>
+      <a href="process.html" class="hover:text-yellow-400">Process</a>
+      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="contact.html" class="inline-block bg-yellow-500 text-gray-900 px-6 py-2 rounded-full hover:bg-yellow-600">Request a Quote</a>
+    </div>
+  </header>
 <main class="flex-grow">
 
 <section class="max-w-4xl mx-auto px-4 py-20">
@@ -29,5 +44,6 @@
     © 2025 Demo Yard · Built by Scrapyard Sites
   </div>
 </footer>
+<script src="script.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -10,11 +10,26 @@
 <header class="bg-gray-800 sticky top-0 w-full z-50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6">
+    <nav class="space-x-6 hidden md:block">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-yellow-400">Contact</a>
     </nav>
-  </div>
-</header>
+    <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+      </svg>
+    </button>
+    </div>
+    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-40 flex flex-col items-center justify-center space-y-6 text-xl transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      <a href="services.html" class="hover:text-yellow-400">Services</a>
+      <a href="locations.html" class="hover:text-yellow-400">Locations</a>
+      <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>
+      <a href="about.html" class="hover:text-yellow-400">About</a>
+      <a href="process.html" class="hover:text-yellow-400">Process</a>
+      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="contact.html" class="inline-block bg-yellow-500 text-gray-900 px-6 py-2 rounded-full hover:bg-yellow-600">Request a Quote</a>
+    </div>
+  </header>
 <main class="flex-grow">
 
 <section class="max-w-4xl mx-auto px-4 py-20">
@@ -42,5 +57,6 @@
     © 2025 Demo Yard · Built by Scrapyard Sites
   </div>
 </footer>
+<script src="script.js"></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -10,11 +10,26 @@
 <header class="bg-gray-800 sticky top-0 w-full z-50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6">
+    <nav class="space-x-6 hidden md:block">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-yellow-400">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
-  </div>
-</header>
+    <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+      </svg>
+    </button>
+    </div>
+    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-40 flex flex-col items-center justify-center space-y-6 text-xl transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      <a href="services.html" class="hover:text-yellow-400">Services</a>
+      <a href="locations.html" class="hover:text-yellow-400">Locations</a>
+      <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>
+      <a href="about.html" class="hover:text-yellow-400">About</a>
+      <a href="process.html" class="hover:text-yellow-400">Process</a>
+      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="contact.html" class="inline-block bg-yellow-500 text-gray-900 px-6 py-2 rounded-full hover:bg-yellow-600">Request a Quote</a>
+    </div>
+  </header>
 <main class="flex-grow">
 
 <section class="max-w-4xl mx-auto px-4 py-20">
@@ -41,5 +56,6 @@
     © 2025 Demo Yard · Built by Scrapyard Sites
   </div>
 </footer>
+<script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,11 +10,26 @@
 <header class="bg-gray-800 sticky top-0 w-full z-50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6">
+    <nav class="space-x-6 hidden md:block">
       <a href="index.html" class="text-sm font-medium text-yellow-400">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
-  </div>
-</header>
+    <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+      </svg>
+    </button>
+    </div>
+    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-40 flex flex-col items-center justify-center space-y-6 text-xl transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      <a href="services.html" class="hover:text-yellow-400">Services</a>
+      <a href="locations.html" class="hover:text-yellow-400">Locations</a>
+      <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>
+      <a href="about.html" class="hover:text-yellow-400">About</a>
+      <a href="process.html" class="hover:text-yellow-400">Process</a>
+      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="contact.html" class="inline-block bg-yellow-500 text-gray-900 px-6 py-2 rounded-full hover:bg-yellow-600">Request a Quote</a>
+    </div>
+  </header>
 <main class="flex-grow">
 
 <section class="relative h-screen flex items-center justify-center text-center">
@@ -96,5 +111,6 @@
     © 2025 Demo Yard · Built by Scrapyard Sites
   </div>
 </footer>
+<script src="script.js"></script>
 </body>
 </html>

--- a/locations.html
+++ b/locations.html
@@ -10,11 +10,26 @@
 <header class="bg-gray-800 sticky top-0 w-full z-50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6">
+    <nav class="space-x-6 hidden md:block">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-yellow-400">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
-  </div>
-</header>
+    <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+      </svg>
+    </button>
+    </div>
+    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-40 flex flex-col items-center justify-center space-y-6 text-xl transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      <a href="services.html" class="hover:text-yellow-400">Services</a>
+      <a href="locations.html" class="hover:text-yellow-400">Locations</a>
+      <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>
+      <a href="about.html" class="hover:text-yellow-400">About</a>
+      <a href="process.html" class="hover:text-yellow-400">Process</a>
+      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="contact.html" class="inline-block bg-yellow-500 text-gray-900 px-6 py-2 rounded-full hover:bg-yellow-600">Request a Quote</a>
+    </div>
+  </header>
 <main class="flex-grow">
 
 <section class="max-w-7xl mx-auto px-4 py-20">
@@ -43,5 +58,6 @@
     © 2025 Demo Yard · Built by Scrapyard Sites
   </div>
 </footer>
+<script src="script.js"></script>
 </body>
 </html>

--- a/pricing.html
+++ b/pricing.html
@@ -10,11 +10,26 @@
 <header class="bg-gray-800 sticky top-0 w-full z-50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6">
+    <nav class="space-x-6 hidden md:block">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-yellow-400">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
-  </div>
-</header>
+    <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+      </svg>
+    </button>
+    </div>
+    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-40 flex flex-col items-center justify-center space-y-6 text-xl transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      <a href="services.html" class="hover:text-yellow-400">Services</a>
+      <a href="locations.html" class="hover:text-yellow-400">Locations</a>
+      <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>
+      <a href="about.html" class="hover:text-yellow-400">About</a>
+      <a href="process.html" class="hover:text-yellow-400">Process</a>
+      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="contact.html" class="inline-block bg-yellow-500 text-gray-900 px-6 py-2 rounded-full hover:bg-yellow-600">Request a Quote</a>
+    </div>
+  </header>
 <main class="flex-grow">
 
 <section class="max-w-7xl mx-auto px-4 py-20">
@@ -50,5 +65,6 @@
     © 2025 Demo Yard · Built by Scrapyard Sites
   </div>
 </footer>
+<script src="script.js"></script>
 </body>
 </html>

--- a/process.html
+++ b/process.html
@@ -10,11 +10,26 @@
 <header class="bg-gray-800 sticky top-0 w-full z-50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6">
+    <nav class="space-x-6 hidden md:block">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-yellow-400">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
-  </div>
-</header>
+    <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+      </svg>
+    </button>
+    </div>
+    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-40 flex flex-col items-center justify-center space-y-6 text-xl transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      <a href="services.html" class="hover:text-yellow-400">Services</a>
+      <a href="locations.html" class="hover:text-yellow-400">Locations</a>
+      <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>
+      <a href="about.html" class="hover:text-yellow-400">About</a>
+      <a href="process.html" class="hover:text-yellow-400">Process</a>
+      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="contact.html" class="inline-block bg-yellow-500 text-gray-900 px-6 py-2 rounded-full hover:bg-yellow-600">Request a Quote</a>
+    </div>
+  </header>
 <main class="flex-grow">
 
 <section class="max-w-7xl mx-auto px-4 py-20">
@@ -41,5 +56,6 @@
     © 2025 Demo Yard · Built by Scrapyard Sites
   </div>
 </footer>
+<script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,17 @@
+function toggleMenu() {
+  const menu = document.getElementById('mobileMenu');
+  if (menu) {
+    menu.classList.toggle('hidden');
+    menu.classList.toggle('translate-x-full');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  const btn = document.getElementById('menuButton');
+  if (btn) {
+    btn.addEventListener('click', toggleMenu);
+  }
+  const links = document.querySelectorAll('#mobileMenu a');
+  links.forEach(l => l.addEventListener('click', toggleMenu));
+});
+

--- a/services.html
+++ b/services.html
@@ -10,11 +10,26 @@
 <header class="bg-gray-800 sticky top-0 w-full z-50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6">
+    <nav class="space-x-6 hidden md:block">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-yellow-400">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
-  </div>
-</header>
+    <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+      </svg>
+    </button>
+    </div>
+    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-40 flex flex-col items-center justify-center space-y-6 text-xl transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      <a href="services.html" class="hover:text-yellow-400">Services</a>
+      <a href="locations.html" class="hover:text-yellow-400">Locations</a>
+      <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>
+      <a href="about.html" class="hover:text-yellow-400">About</a>
+      <a href="process.html" class="hover:text-yellow-400">Process</a>
+      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="contact.html" class="inline-block bg-yellow-500 text-gray-900 px-6 py-2 rounded-full hover:bg-yellow-600">Request a Quote</a>
+    </div>
+  </header>
 <main class="flex-grow">
 
 <section class="max-w-7xl mx-auto px-4 py-20">
@@ -53,5 +68,6 @@
     © 2025 Demo Yard · Built by Scrapyard Sites
   </div>
 </footer>
+<script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create `script.js` for menu toggle logic
- add hamburger and slide-in menu to all pages
- hide inline nav on mobile and move CTA button inside the drawer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686040d90d848329a1c073e386ab8cbc