### PR TITLE
Add 'Start My Build' CTAs on pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -27,13 +27,14 @@
         <li>One scrolling page</li><li>Contact form</li><li>Google Map embed</li><li>Basic SEO</li><li>30 days tweaks</li>
       </ul>
     </div>
-    <div class="bg-yellow-500 text-gray-900 rounded-lg p-10 shadow-lg transform scale-105 flex flex-col">
-      <h2 class="text-2xl font-semibold mb-4">Power‑Launch</h2>
-      <p class="text-4xl font-bold mb-8">$5,499</p>
-      <ul class="space-y-2 mb-8 text-sm">
-        <li>Up to 8 pages</li><li>Forms on every page</li><li>Location pages with Maps</li><li>Structured data SEO</li><li>60 days full support</li>
-      </ul>
-    </div>
+      <div class="bg-yellow-500 text-gray-900 rounded-lg p-10 shadow-lg transform scale-105 flex flex-col">
+        <h2 class="text-2xl font-semibold mb-4">Power‑Launch</h2>
+        <p class="text-4xl font-bold mb-8">$5,499</p>
+        <ul class="space-y-2 mb-8 text-sm">
+          <li>Up to 8 pages</li><li>Forms on every page</li><li>Location pages with Maps</li><li>Structured data SEO</li><li>60 days full support</li>
+        </ul>
+        <a href="contact.html" class="bg-gray-900 hover:bg-gray-800 text-yellow-500 font-semibold px-8 py-3 rounded-full transition mt-auto">Start My Build</a>
+      </div>
     <div class="bg-gray-800 rounded-lg p-10 shadow flex flex-col">
       <h2 class="text-2xl font-semibold mb-4">Care Plan</h2>
       <p class="text-4xl font-bold mb-8">$99/mo</p>
@@ -41,6 +42,9 @@
         <li>Unlimited updates</li><li>Security & backups</li><li>Performance reports</li><li>Priority support</li>
       </ul>
     </div>
+  </div>
+  <div class="mt-12 text-center">
+    <a href="contact.html" class="bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-semibold px-10 py-4 rounded-full transition">Start My Build</a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- place a "Start My Build" CTA inside the Power‑Launch pricing card
- add another "Start My Build" CTA below the pricing grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686042155a588329bf6923156f168dda