### PR TITLE
Replace About page icons with premium versions

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,8 +37,8 @@
   <p class="text-lg text-gray-300 leading-8">Demo Yard has served the region for over two decades, built on blue‑collar grit and white‑glove customer service. Our mission is simple: <strong>pay fair prices, process responsibly,</strong> and treat every hauler with respect—whether you’re driving a pickup or a semi.</p>
   <p class="mt-6 text-lg text-gray-300 leading-8">With state‑of‑the‑art shred lines, certified scales, and a 24‑hour payment promise, we’re the yard trusted by contractors, manufacturers, and Fortune 500 recyclers alike.</p>
   <div class="flex justify-center space-x-8 mt-12">
-    <img src="https://placehold.co/120x120?text=ISO+9001" alt="ISO 9001 Certified" class="h-24 w-24 object-contain">
-    <img src="https://placehold.co/120x120?text=25%2B+Years" alt="25 Years in Business" class="h-24 w-24 object-contain">
+    <img src="https://img.icons8.com/fluency/96/certificate.png" alt="ISO 9001 Certified" class="h-24 w-24 object-contain">
+    <img src="https://img.icons8.com/fluency/96/trophy.png" alt="25 Years in Business" class="h-24 w-24 object-contain">
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- switch ISO certification and years-in-business icons to Icons8 graphics on About page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6860442f3a788329a78388c3f4e55378