### PR TITLE
Update home page overlay and add stat animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,11 +33,12 @@
 <main class="flex-grow">
 
 <section class="relative h-screen flex items-center justify-center text-center">
-  <img src="https://images.unsplash.com/photo-1507967000381-287232a08ffb?auto=format&fit=crop&w=1920&q=80" alt="" class="absolute inset-0 w-full h-full object-cover opacity-40">
+  <img src="https://images.unsplash.com/photo-1507967000381-287232a08ffb?auto=format&fit=crop&w=1920&q=80" alt="" class="absolute inset-0 w-full h-full object-cover">
+  <div class="absolute inset-0 bg-black opacity-50"></div>
   <div class="relative z-10 max-w-4xl mx-auto px-4">
     <h1 class="text-5xl md:text-7xl font-extrabold mb-6 leading-tight">Top Dollar for Scrap Metal – Fast, Fair, &amp; Reliable</h1>
     <p class="text-xl mb-8">Serving the metro area with 24‑hour turnarounds and honest weights.</p>
-    <a href="contact.html" class="inline-block bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-semibold px-8 py-4 rounded-full transition">Request a Quote</a>
+    <a href="process.html" class="inline-block bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-semibold px-8 py-4 rounded-full transition">Request a Quote</a>
   </div>
 </section>
 
@@ -74,9 +75,18 @@
 
 <section class="bg-gradient-to-r from-yellow-500 to-orange-600 py-20">
   <div class="max-w-5xl mx-auto px-4 grid md:grid-cols-3 gap-10 text-center text-gray-900 font-extrabold">
-    <div><p class="text-6xl mb-2">50+</p><p class="uppercase tracking-wide text-sm font-bold">Years Combined Experience</p></div>
-    <div><p class="text-6xl mb-2">24h</p><p class="uppercase tracking-wide text-sm font-bold">Average Turnaround</p></div>
-    <div><p class="text-6xl mb-2">100%</p><p class="uppercase tracking-wide text-sm font-bold">Satisfaction Guarantee</p></div>
+    <div>
+      <p class="text-6xl mb-2"><span class="stat-number" data-target="50" data-suffix="+">50+</span></p>
+      <p class="uppercase tracking-wide text-sm font-bold">Years Combined Experience</p>
+    </div>
+    <div>
+      <p class="text-6xl mb-2"><span class="stat-number" data-target="24" data-suffix="h">24h</span></p>
+      <p class="uppercase tracking-wide text-sm font-bold">Average Turnaround</p>
+    </div>
+    <div>
+      <p class="text-6xl mb-2"><span class="stat-number" data-target="100" data-suffix="%">100%</span></p>
+      <p class="uppercase tracking-wide text-sm font-bold">Satisfaction Guarantee</p>
+    </div>
   </div>
 </section>
 
@@ -91,7 +101,7 @@
 <section class="py-20 bg-gray-800">
   <div class="max-w-4xl mx-auto text-center">
     <h2 class="text-3xl font-bold mb-6">Ready to turn scrap into cash?</h2>
-    <a href="contact.html" class="bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-semibold px-10 py-4 rounded-full transition">Book a Container</a>
+    <a href="contact.html" class="bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-semibold px-10 py-4 rounded-full transition">Request a Quote</a>
   </div>
 </section>
 

--- a/script.js
+++ b/script.js
@@ -13,5 +13,38 @@ document.addEventListener('DOMContentLoaded', function () {
   }
   const links = document.querySelectorAll('#mobileMenu a');
   links.forEach(l => l.addEventListener('click', toggleMenu));
+
+  const counters = document.querySelectorAll('.stat-number');
+  if (counters.length) {
+    const animate = (el) => {
+      const target = parseInt(el.getAttribute('data-target'), 10) || 0;
+      const suffix = el.getAttribute('data-suffix') || '';
+      let start = 0;
+      const duration = 1500;
+      const step = Math.max(Math.floor(duration / target), 20);
+      const increment = target / (duration / step);
+      const update = () => {
+        start += increment;
+        if (start >= target) {
+          el.textContent = target + suffix;
+        } else {
+          el.textContent = Math.floor(start) + suffix;
+          setTimeout(update, step);
+        }
+      };
+      update();
+    };
+
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          animate(entry.target);
+          obs.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.6 });
+
+    counters.forEach(el => observer.observe(el));
+  }
 });
 


### PR DESCRIPTION
## Summary
- darken hero image overlay and link hero button to `process.html`
- animate stats on scroll
- show `Request a Quote` instead of `Book a Container`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68604b6b79e4832980465ab8519b4914