### PR TITLE
Add trust signal and fine print to pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -44,7 +44,8 @@
     </div>
       <div class="bg-yellow-500 text-gray-900 rounded-lg p-10 shadow-lg transform scale-105 flex flex-col">
         <h2 class="text-2xl font-semibold mb-4">Power‑Launch</h2>
-        <p class="text-4xl font-bold mb-8">$5,499</p>
+        <p class="text-4xl font-bold">$5,499</p>
+        <p class="text-xs mb-8">30-day satisfaction guarantee</p>
         <ul class="space-y-2 mb-8 text-sm">
           <li>Up to 8 pages</li><li>Forms on every page</li><li>Location pages with Maps</li><li>Structured data SEO</li><li>60 days full support</li>
         </ul>
@@ -60,6 +61,7 @@
   </div>
   <div class="mt-12 text-center">
     <a href="contact.html" class="bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-semibold px-10 py-4 rounded-full transition">Start My Build</a>
+    <p class="mt-4 text-xs text-gray-400">Custom enterprise quotes available</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- highlight 30‑day satisfaction guarantee under the Power‑Launch price
- mention that custom enterprise quotes are available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68604c0c7fb88329a332ef95cbc865d5