### PR TITLE
Enhance process page visuals

### DIFF
--- a/process.html
+++ b/process.html
@@ -73,46 +73,58 @@
   <div class="space-y-12">
     <div class="md:flex md:justify-between md:items-start">
       <div class="md:w-5/12 md:pr-8 md:text-right">
-        <div class="bg-gray-800 rounded-lg p-6 shadow">
-          <h3 class="text-xl font-semibold">Lock‑In Pricing</h3>
-          <ul class="list-disc pl-6 text-gray-400 space-y-2">
-            <li>Call, text, or hit “Request a Quote.” We confirm today’s market price and reserve it for you—no surprise downgrades at the scale.</li>
-            <li>Need a roll‑off? Our dispatcher schedules delivery within 24&nbsp;hours.</li>
-            <li>Every quote arrives with a digital ticket so you know the exact grade, weight, and rate before a single pound moves.</li>
-          </ul>
+        <div class="bg-gray-800 rounded-lg p-6 shadow flex">
+          <div class="flex items-center mr-4">
+            <svg class="w-8 h-8 text-yellow-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M12 1.5a5.25 5.25 0 0 0-5.25 5.25v3a3 3 0 0 0-3 3v6.75a3 3 0 0 0 3 3h10.5a3 3 0 0 0 3-3v-6.75a3 3 0 0 0-3-3v-3c0-2.9-2.35-5.25-5.25-5.25Zm3.75 8.25v-3a3.75 3.75 0 1 0-7.5 0v3h7.5Z" clip-rule="evenodd"/></svg>
+          </div>
+          <div>
+            <h3 class="text-xl font-semibold">Lock‑In Pricing</h3>
+            <ul class="list-disc pl-6 text-gray-400 space-y-2">
+              <li>Call, text, or hit “Request a Quote.” We confirm today’s market price and reserve it for you—no surprise downgrades at the scale.</li>
+              <li>Need a roll‑off? Our dispatcher schedules delivery within 24&nbsp;hours.</li>
+              <li>Every quote arrives with a digital ticket so you know the exact grade, weight, and rate before a single pound moves.</li>
+            </ul>
+          </div>
         </div>
       </div>
-      <div class="flex items-center justify-center w-10 h-10 rounded-full bg-yellow-500 text-gray-900 font-bold mx-auto md:mx-0 my-8 md:my-0">1</div>
       <div class="md:w-5/12"></div>
     </div>
 
     <div class="md:flex md:justify-between md:items-start">
       <div class="md:w-5/12 hidden md:block"></div>
-      <div class="flex items-center justify-center w-10 h-10 rounded-full bg-yellow-500 text-gray-900 font-bold mx-auto md:mx-0 my-8 md:my-0">2</div>
       <div class="md:w-5/12 md:pl-8">
-        <div class="bg-gray-800 rounded-lg p-6 shadow">
-          <h3 class="text-xl font-semibold">Roll In &amp; Weigh Up</h3>
-          <ul class="list-disc pl-6 text-gray-400 space-y-2">
-            <li>Pull onto our state‑certified scales; attendants guide you from start to finish.</li>
-            <li>A live display shows gross, tare, and net weights in real time—scan the screen, snap a photo if you like.</li>
-            <li>Forklifts and magnets unload your material fast, keeping you in the cab and off your clock.</li>
-          </ul>
+        <div class="bg-gray-800 rounded-lg p-6 shadow flex">
+          <div class="flex items-center mr-4">
+            <svg class="w-8 h-8 text-yellow-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M3.375 4.5C2.339 4.5 1.5 5.34 1.5 6.375V13.5h12V6.375c0-1.036-.84-1.875-1.875-1.875h-8.25ZM13.5 15h-12v2.625c0 1.035.84 1.875 1.875 1.875h.375a3 3 0 1 1 6 0h3a.75.75 0 0 0 .75-.75V15Z"/><path d="M8.25 19.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0ZM15.75 6.75a.75.75 0 0 0-.75.75v11.25c0 .087.015.17.042.248a3 3 0 0 1 5.958.464c.853-.175 1.522-.935 1.464-1.883a18.659 18.659 0 0 0-3.732-10.104 1.837 1.837 0 0 0-1.47-.725H15.75Z"/><path d="M19.5 19.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0Z"/></svg>
+          </div>
+          <div>
+            <h3 class="text-xl font-semibold">Roll In &amp; Weigh Up</h3>
+            <ul class="list-disc pl-6 text-gray-400 space-y-2">
+              <li>Pull onto our state‑certified scales; attendants guide you from start to finish.</li>
+              <li>A live display shows gross, tare, and net weights in real time—scan the screen, snap a photo if you like.</li>
+              <li>Forklifts and magnets unload your material fast, keeping you in the cab and off your clock.</li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
 
     <div class="md:flex md:justify-between md:items-start">
       <div class="md:w-5/12 md:pr-8 md:text-right">
-        <div class="bg-gray-800 rounded-lg p-6 shadow">
-          <h3 class="text-xl font-semibold">Cash Out &amp; Recycle Right</h3>
-          <ul class="list-disc pl-6 text-gray-400 space-y-2">
-            <li>We print your finalized ticket and trigger payment on the spot—check, ACH, or payment card.</li>
-            <li>Your scrap heads straight to our shred, shear, or baler lines, where we recover 99&nbsp;% of recyclable metal and divert the rest from landfill.</li>
-            <li>Need certificates of destruction or downstream traceability? They’re in your inbox before you’re back on the road.</li>
-          </ul>
+        <div class="bg-gray-800 rounded-lg p-6 shadow flex">
+          <div class="flex items-center mr-4">
+            <svg class="w-8 h-8 text-yellow-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 7.5a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Z"/><path fill-rule="evenodd" d="M1.5 4.875C1.5 3.839 2.34 3 3.375 3h17.25c1.035 0 1.875.84 1.875 1.875v9.75c0 1.036-.84 1.875-1.875 1.875H3.375A1.875 1.875 0 0 1 1.5 14.625v-9.75ZM8.25 9.75a3.75 3.75 0 1 1 7.5 0 3.75 3.75 0 0 1-7.5 0ZM18.75 9a.75.75 0 0 0-.75.75v.008c0 .414.336.75.75.75h.008a.75.75 0 0 0 .75-.75V9.75a.75.75 0 0 0-.75-.75h-.008ZM4.5 9.75A.75.75 0 0 1 5.25 9h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V9.75Z" clip-rule="evenodd"/><path d="M2.25 18a.75.75 0 0 0 0 1.5c5.4 0 10.63.722 15.6 2.075 1.19.324 2.4-.558 2.4-1.82V18.75a.75.75 0 0 0-.75-.75H2.25Z"/></svg>
+          </div>
+          <div>
+            <h3 class="text-xl font-semibold">Cash Out &amp; Recycle Right</h3>
+            <ul class="list-disc pl-6 text-gray-400 space-y-2">
+              <li>We print your finalized ticket and trigger payment on the spot—check, ACH, or payment card.</li>
+              <li>Your scrap heads straight to our shred, shear, or baler lines, where we recover 99&nbsp;% of recyclable metal and divert the rest from landfill.</li>
+              <li>Need certificates of destruction or downstream traceability? They’re in your inbox before you’re back on the road.</li>
+            </ul>
+          </div>
         </div>
       </div>
-      <div class="flex items-center justify-center w-10 h-10 rounded-full bg-yellow-500 text-gray-900 font-bold mx-auto md:mx-0 my-8 md:my-0">3</div>
       <div class="md:w-5/12"></div>
     </div>
   </div>
@@ -120,10 +132,6 @@
 
 
   <p class="text-center text-gray-400 max-w-3xl mx-auto mt-12">Total yard time for most loads: under 15&nbsp;minutes. Total turnaround from quote to cash: under 24&nbsp;hours.</p>
-  <ul class="list-disc list-inside text-sm text-gray-400 max-w-3xl mx-auto mt-2">
-    <li>Avg. yard time: 14&nbsp;min</li>
-    <li>99% on-time payments</li>
-  </ul>
   <p class="text-center mt-6">Ready to put the process to work for you? Tap “Get My Quote” and drive the shortest distance between scrap and money.</p>
   <div class="mt-8 text-center">
     <a href="contact.html" class="inline-block bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-semibold px-10 py-4 rounded-full transition">Get My Quote</a>


### PR DESCRIPTION
## Summary
- replace numbered step circles with inline icons
- show icon left of card content
- remove avg. yard time and payment statistic list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686051983d808329a926fda5667af98d