### PR TITLE
Adjust CTA spacing on pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -91,7 +91,7 @@
   </div>
   <div class="mt-12 text-center">
     <a href="contact.html" class="bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-semibold px-10 py-4 rounded-full transition">Start My Build</a>
-    <p class="mt-4 text-xs text-gray-400">Custom enterprise quotes available</p>
+  <p class="mt-6 text-xs text-gray-400">Custom enterprise quotes available</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- space small text farther from CTA on pricing page

## Testing
- `tidy -e pricing.html`

------
https://chatgpt.com/codex/tasks/task_e_686057faee488329b3b349d4ef275d70