### PR TITLE
Add bottom border to navbar

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,7 +32,7 @@
 </script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
-<header class="bg-gray-800 sticky top-0 w-full z-50">
+<header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="space-x-6 hidden md:block">

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2,3 +2,7 @@
   border: 2px solid #f59e0b;
   border-radius: 0.5rem; /* match rounded-lg */
 }
+
+.navbar-border {
+  border-bottom: 2px solid #f59e0b;
+}

--- a/contact.html
+++ b/contact.html
@@ -32,7 +32,7 @@
 </script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
-<header class="bg-gray-800 sticky top-0 w-full z-50">
+<header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="space-x-6 hidden md:block">

--- a/faq.html
+++ b/faq.html
@@ -33,7 +33,7 @@
 
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
-<header class="bg-gray-800 sticky top-0 w-full z-50">
+<header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="space-x-6 hidden md:block">

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 </script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
-<header class="bg-gray-800 sticky top-0 w-full z-50">
+<header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="space-x-6 hidden md:block">

--- a/locations.html
+++ b/locations.html
@@ -32,7 +32,7 @@
 </script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
-<header class="bg-gray-800 sticky top-0 w-full z-50">
+<header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="space-x-6 hidden md:block">

--- a/pricing.html
+++ b/pricing.html
@@ -32,7 +32,7 @@
 </script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
-<header class="bg-gray-800 sticky top-0 w-full z-50">
+<header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="space-x-6 hidden md:block">

--- a/process.html
+++ b/process.html
@@ -32,7 +32,7 @@
 </script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
-<header class="bg-gray-800 sticky top-0 w-full z-50">
+<header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="space-x-6 hidden md:block">

--- a/services.html
+++ b/services.html
@@ -32,7 +32,7 @@
 </script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
-<header class="bg-gray-800 sticky top-0 w-full z-50">
+<header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="space-x-6 hidden md:block">


### PR DESCRIPTION
## Summary
- add `.navbar-border` style for yellow bottom border matching card borders
- apply `.navbar-border` class to navbars across all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68605c3de6f483298e78701cfd820e03