### PR TITLE
Update Power-Launch card border color

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2,3 +2,8 @@
   border: 2px solid #f59e0b;
   border-radius: 0.5rem; /* match rounded-lg */
 }
+
+/* Special styling for the yellow Power‑Launch pricing card */
+.power-launch-card {
+  border-color: #111827; /* dark gray to stand out against yellow background */
+}

--- a/pricing.html
+++ b/pricing.html
@@ -73,7 +73,7 @@
         <li>One scrolling page</li><li>Contact form</li><li>Google Map embed</li><li>Basic SEO</li><li>30 days tweaks</li>
       </ul>
     </div>
-      <div class="bg-yellow-500 text-gray-900 rounded-lg p-10 shadow-lg transform scale-105 flex flex-col card">
+      <div class="bg-yellow-500 text-gray-900 rounded-lg p-10 shadow-lg transform scale-105 flex flex-col card power-launch-card">
         <h2 class="text-2xl font-semibold mb-4">Power‑Launch</h2>
         <p class="text-4xl font-bold">$5,499</p>
         <p class="text-xs mb-8">30-day satisfaction guarantee</p>


### PR DESCRIPTION
## Summary
- tweak pricing card style so the yellow Power-Launch card has a dark border

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68605c4e61b0832983feca4e03bcc9bf