### PR TITLE
Add Call Now CTA to desktop nav and center links

### DIFF
--- a/about.html
+++ b/about.html
@@ -33,11 +33,12 @@
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6 hidden md:block">
+    <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-yellow-400">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
+    <a href="contact.html" class="hidden md:inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-6">Call Now</a>
     <a href="contact.html" class="md:hidden inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-auto mr-3">Call Now</a>
     <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/contact.html
+++ b/contact.html
@@ -33,11 +33,12 @@
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6 hidden md:block">
+    <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-yellow-400">Contact</a>
     </nav>
+    <a href="contact.html" class="hidden md:inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-6">Call Now</a>
     <a href="contact.html" class="md:hidden inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-auto mr-3">Call Now</a>
     <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/faq.html
+++ b/faq.html
@@ -34,11 +34,12 @@
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6 hidden md:block">
+    <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-yellow-400">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
+    <a href="contact.html" class="hidden md:inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-6">Call Now</a>
     <a href="contact.html" class="md:hidden inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-auto mr-3">Call Now</a>
     <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/index.html
+++ b/index.html
@@ -33,11 +33,12 @@
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6 hidden md:block">
+    <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-yellow-400">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
+    <a href="contact.html" class="hidden md:inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-6">Call Now</a>
     <a href="contact.html" class="md:hidden inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-auto mr-3">Call Now</a>
     <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/locations.html
+++ b/locations.html
@@ -33,11 +33,12 @@
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6 hidden md:block">
+    <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-yellow-400">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
+    <a href="contact.html" class="hidden md:inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-6">Call Now</a>
     <a href="contact.html" class="md:hidden inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-auto mr-3">Call Now</a>
     <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/pricing.html
+++ b/pricing.html
@@ -33,11 +33,12 @@
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6 hidden md:block">
+    <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-yellow-400">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
+    <a href="contact.html" class="hidden md:inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-6">Call Now</a>
     <a href="contact.html" class="md:hidden inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-auto mr-3">Call Now</a>
     <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/process.html
+++ b/process.html
@@ -33,11 +33,12 @@
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6 hidden md:block">
+    <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-yellow-400">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
+    <a href="contact.html" class="hidden md:inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-6">Call Now</a>
     <a href="contact.html" class="md:hidden inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-auto mr-3">Call Now</a>
     <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/services.html
+++ b/services.html
@@ -33,11 +33,12 @@
 </head>
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
-    <nav class="space-x-6 hidden md:block">
+    <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-yellow-400">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>
     </nav>
+    <a href="contact.html" class="hidden md:inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-6">Call Now</a>
     <a href="contact.html" class="md:hidden inline-block bg-yellow-500 text-gray-900 px-4 py-2 rounded-full ml-auto mr-3">Call Now</a>
     <button id="menuButton" class="md:hidden text-gray-300 hover:text-white focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- show a desktop Call Now button in the navbar
- center the navigation links on desktop

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68605eb9f4548329a211014eab7f6db0