### PR TITLE
Fix JS error to enable hamburger menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', function () {
       }
       form.reset();
     });
+  }
 
   const accordions = document.querySelectorAll('details');
   accordions.forEach(d => {


### PR DESCRIPTION
## Summary
- fix missing brace in `script.js` preventing DOMContentLoaded handler from running

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_68606494b4b0832984d331d09cc451a5