### PR TITLE
Add logo to navigation bar

### DIFF
--- a/about.html
+++ b/about.html
@@ -35,6 +35,7 @@
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
+    <img src="assets/logo.svg" alt="Demo Yard logo" class="h-8 w-auto mr-2">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-yellow-400">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="16" fill="#D97706"/>
+  <text x="16" y="21" font-family="Arial" font-size="12" text-anchor="middle" fill="white">DY</text>
+</svg>

--- a/contact.html
+++ b/contact.html
@@ -35,6 +35,7 @@
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
+    <img src="assets/logo.svg" alt="Demo Yard logo" class="h-8 w-auto mr-2">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-yellow-400">Contact</a>

--- a/faq.html
+++ b/faq.html
@@ -36,6 +36,7 @@
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
+    <img src="assets/logo.svg" alt="Demo Yard logo" class="h-8 w-auto mr-2">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-yellow-400">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
+    <img src="assets/logo.svg" alt="Demo Yard logo" class="h-8 w-auto mr-2">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-yellow-400">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>

--- a/locations.html
+++ b/locations.html
@@ -35,6 +35,7 @@
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
+    <img src="assets/logo.svg" alt="Demo Yard logo" class="h-8 w-auto mr-2">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-yellow-400">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>

--- a/pricing.html
+++ b/pricing.html
@@ -35,6 +35,7 @@
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
+    <img src="assets/logo.svg" alt="Demo Yard logo" class="h-8 w-auto mr-2">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-yellow-400">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>

--- a/process.html
+++ b/process.html
@@ -35,6 +35,7 @@
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
+    <img src="assets/logo.svg" alt="Demo Yard logo" class="h-8 w-auto mr-2">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-gray-300 hover:text-white">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-yellow-400">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>

--- a/services.html
+++ b/services.html
@@ -35,6 +35,7 @@
 <body class="min-h-screen flex flex-col bg-gray-900 text-gray-100">
 <header class="bg-gray-800 sticky top-0 w-full z-50 navbar-border">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
+    <img src="assets/logo.svg" alt="Demo Yard logo" class="h-8 w-auto mr-2">
     <a href="index.html" class="text-xl font-extrabold text-white">Demo Yard</a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="index.html" class="text-sm font-medium text-gray-300 hover:text-white">Home</a><a href="services.html" class="text-sm font-medium text-yellow-400">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300 hover:text-white">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300 hover:text-white">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300 hover:text-white">About</a><a href="process.html" class="text-sm font-medium text-gray-300 hover:text-white">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300 hover:text-white">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300 hover:text-white">Contact</a>


### PR DESCRIPTION
## Summary
- include `logo.svg` before the site title in every page's navigation
- add the `assets/logo.svg` image asset

## Testing
- `npm test` *(fails: no `package.json`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686066abc3b48329bec726dbc4a9c58e