### PR TITLE
Animate stats section gradient

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -68,3 +68,16 @@ body {
 .text-brand-charcoal { color: var(--color-headlines) !important; }
 .bg-brand-charcoal { background-color: var(--color-headlines) !important; }
 .border-brand-steel { border-color: var(--color-success) !important; }
+
+/* Animated background for the stats section */
+.stats-gradient {
+  background: linear-gradient(-45deg, #D75E02, #FFA726, #FF6A00, #D75E02);
+  background-size: 600% 600%;
+  animation: stats-gradient-animation 10s ease infinite;
+}
+
+@keyframes stats-gradient-animation {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
   </div>
 </section>
 
-<section class="bg-gradient-to-r from-red-500 to-red-700 py-20">
+<section class="stats-gradient py-20">
   <div class="max-w-5xl mx-auto px-4 grid md:grid-cols-3 gap-10 text-center text-gray-900 font-extrabold">
     <div>
       <p class="text-6xl mb-2"><span class="stat-number" data-target="50" data-suffix="+">50+</span></p>


### PR DESCRIPTION
## Summary
- switch stats section to use a custom animated gradient
- add styles for orange gradient animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686077cc25cc83298e6063c11af2f4ca