### PR TITLE
Add colon to hero header

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 
   <div class="mx-auto max-w-3xl px-6">
     <h1 class="text-4xl sm:text-5xl md:text-6xl font-extrabold leading-tight text-white drop-shadow-lg">
-      Top Dollar for <span class="text-brand-orange">Scrap Metal</span>
+      Top Dollar for <span class="text-brand-orange">Scrap Metal</span>:
       <br class="hidden sm:block"/>
       Fast, Fair, &amp; Reliable
     </h1>


### PR DESCRIPTION
## Summary
- add a white colon after `Scrap Metal` in the hero header

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68607e57e3e08329b338d61855f62a1e