### PR TITLE
Fix sticky navbar

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -77,6 +77,7 @@ body {
 
 /* Ensure navbar stays sticky even if Tailwind fails to load */
 header.sticky {
+  position: -webkit-sticky;
   position: sticky;
   top: 0;
   z-index: 50; /* match z-50 utility */


### PR DESCRIPTION
## Summary
- add `-webkit-sticky` prefix to the sticky header rule for better browser support

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68608000894c8329a79cd4497a4c1afb