### PR TITLE
Fix sticky nav

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -81,6 +81,7 @@ header.sticky {
   position: sticky;
   top: 0;
   z-index: 50; /* match z-50 utility */
+  flex-shrink: 0; /* prevent collapsing in flex layouts */
 }
 
 /* Nav bar underline animation */


### PR DESCRIPTION
## Summary
- keep header from shrinking in flex layouts so the sticky nav works reliably

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_68608518beec8329af428a9592244aaa