### PR TITLE
Remove Home link from navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -67,7 +67,7 @@
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="index.html" class="text-sm font-medium text-gray-300">Home</a><a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-yellow-400">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-yellow-400">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -83,7 +83,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
       </button>
-      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      
       <a href="services.html" class="hover:text-yellow-400">Services</a>
       <a href="locations.html" class="hover:text-yellow-400">Locations</a>
       <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>

--- a/contact.html
+++ b/contact.html
@@ -67,7 +67,7 @@
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="index.html" class="text-sm font-medium text-gray-300">Home</a><a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-yellow-400">Contact</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-yellow-400">Contact</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -83,7 +83,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
       </button>
-      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      
       <a href="services.html" class="hover:text-yellow-400">Services</a>
       <a href="locations.html" class="hover:text-yellow-400">Locations</a>
       <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>

--- a/faq.html
+++ b/faq.html
@@ -68,7 +68,7 @@
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="index.html" class="text-sm font-medium text-gray-300">Home</a><a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-yellow-400">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-yellow-400">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -84,7 +84,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
       </button>
-      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      
       <a href="services.html" class="hover:text-yellow-400">Services</a>
       <a href="locations.html" class="hover:text-yellow-400">Locations</a>
       <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="index.html" class="text-sm font-medium text-yellow-400">Home</a><a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -83,7 +83,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
       </button>
-      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      
       <a href="services.html" class="hover:text-yellow-400">Services</a>
       <a href="locations.html" class="hover:text-yellow-400">Locations</a>
       <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>

--- a/locations.html
+++ b/locations.html
@@ -67,7 +67,7 @@
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="index.html" class="text-sm font-medium text-gray-300">Home</a><a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-yellow-400">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-yellow-400">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -83,7 +83,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
       </button>
-      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      
       <a href="services.html" class="hover:text-yellow-400">Services</a>
       <a href="locations.html" class="hover:text-yellow-400">Locations</a>
       <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>

--- a/pricing.html
+++ b/pricing.html
@@ -67,7 +67,7 @@
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="index.html" class="text-sm font-medium text-gray-300">Home</a><a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-yellow-400">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-yellow-400">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -83,7 +83,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
       </button>
-      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      
       <a href="services.html" class="hover:text-yellow-400">Services</a>
       <a href="locations.html" class="hover:text-yellow-400">Locations</a>
       <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>

--- a/process.html
+++ b/process.html
@@ -67,7 +67,7 @@
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="index.html" class="text-sm font-medium text-gray-300">Home</a><a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-yellow-400">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-yellow-400">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -83,7 +83,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
       </button>
-      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      
       <a href="services.html" class="hover:text-yellow-400">Services</a>
       <a href="locations.html" class="hover:text-yellow-400">Locations</a>
       <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>

--- a/services.html
+++ b/services.html
@@ -67,7 +67,7 @@
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="index.html" class="text-sm font-medium text-gray-300">Home</a><a href="services.html" class="text-sm font-medium text-yellow-400">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
+      <a href="services.html" class="text-sm font-medium text-yellow-400">Services</a><a href="locations.html" class="text-sm font-medium text-gray-300">Locations</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -83,7 +83,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
       </button>
-      <a href="index.html" class="hover:text-yellow-400">Home</a>
+      
       <a href="services.html" class="hover:text-yellow-400">Services</a>
       <a href="locations.html" class="hover:text-yellow-400">Locations</a>
       <a href="pricing.html" class="hover:text-yellow-400">Pricing</a>


### PR DESCRIPTION
## Summary
- remove `Home` link from navigation and mobile menu across all pages

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686095a8461883298827e770c510330d