### PR TITLE
Update step icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,31 +189,31 @@
   </div>
 
   <div class="mt-16 grid gap-8 md:grid-cols-3 max-w-6xl mx-auto px-6">
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex items-start md:flex-col md:text-center">
-      <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
-        <i class="fa-solid fa-1"></i>
+    <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex flex-col items-center text-center">
+      <div class="text-brand-orange text-5xl mb-4">
+        <i class="fa-solid fa-circle-1"></i>
       </div>
-      <div class="text-left md:text-center">
+      <div>
         <h3 class="font-semibold text-lg mb-2">Check Your Material</h3>
         <p class="text-base md:text-sm text-brand-steel">We accept Copper &amp; Brass, Aluminum (sheet, cast &amp; cans), Steel &amp; Iron, Stainless Steel, Catalytic Converters, E-Scrap &amp; Batteries, and more! <br><br>Need the full list? Tap View All Materials to see every item we take—and the few we don’t (haz-mat, sealed tanks, liquids).</p>
       </div>
     </div>
 
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex items-start md:flex-col md:text-center">
-      <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
-        <i class="fa-solid fa-2"></i>
+    <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex flex-col items-center text-center">
+      <div class="text-brand-orange text-5xl mb-4">
+        <i class="fa-solid fa-circle-2"></i>
       </div>
-      <div class="text-left md:text-center">
+      <div>
         <h3 class="font-semibold text-lg mb-2">Drive On &amp; Unload</h3>
         <p class="text-base md:text-sm text-brand-steel">Roll onto our calibrated truck scale, grab a yard pass, and follow the clearly-marked lanes. Our crew will grade, sort, and unload for you—so you’re back on the road fast. <br><br>First time here? Tap <a href="https://maps.google.com" class="underline">here for Google Maps</a> directions or call us at xxx.xxx.xxxx to get more info.</p>
       </div>
     </div>
 
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex items-start md:flex-col md:text-center">
-      <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
-        <i class="fa-solid fa-3"></i>
+    <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex flex-col items-center text-center">
+      <div class="text-brand-orange text-5xl mb-4">
+        <i class="fa-solid fa-circle-3"></i>
       </div>
-      <div class="text-left md:text-center">
+      <div>
         <h3 class="font-semibold text-lg mb-2">Get Paid—Instantly</h3>
         <p class="text-base md:text-sm text-brand-steel">Watch your weight ticket print, then choose Cash, ACH, or Check on the spot. A live price ticker shows today’s top three metals while you wait.<br><br>Ready to lock in a rate? <a href="contact.html" class="underline">Request a Quote</a> and head our way.</p>
       </div>


### PR DESCRIPTION
## Summary
- update scrap selling steps section with new Font Awesome `fa-circle-n` icons
- center icons horizontally and bump size up to `text-5xl`

## Testing
- `npm test` *(fails: package.json missing)*
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686096d12c2c8329bda1b71741a78263