### PR TITLE
Remove tagline from launch pricing card

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -105,10 +105,6 @@
     <div class="mt-14 grid gap-10 md:grid-cols-3">
       <!-- Launch -->
       <div class="relative bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
-        <span
-          class="absolute -top-4 left-1/2 -translate-x-1/2 bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow">
-          Most yards start here
-        </span>
         <h3 class="text-xl font-semibold mb-4">Launch Package</h3>
         <p class="text-5xl font-extrabold tracking-tight">$2,499</p>
         <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">


### PR DESCRIPTION
## Summary
- update pricing page to drop the "Most yards start here" badge

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_686097379b3c8329a6c4ee5b0008b57e