### PR TITLE
Fix missing icons in steps section

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,10 @@
   <div class="mt-16 grid gap-8 md:grid-cols-3 max-w-6xl mx-auto px-6">
     <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex flex-col items-center text-center">
       <div class="text-brand-orange text-5xl mb-4">
-        <i class="fa-solid fa-circle-1"></i>
+        <span class="fa-stack fa-2x">
+          <i class="fa-solid fa-circle fa-stack-2x"></i>
+          <i class="fa-solid fa-1 fa-stack-1x fa-inverse"></i>
+        </span>
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Check Your Material</h3>
@@ -201,7 +204,10 @@
 
     <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex flex-col items-center text-center">
       <div class="text-brand-orange text-5xl mb-4">
-        <i class="fa-solid fa-circle-2"></i>
+        <span class="fa-stack fa-2x">
+          <i class="fa-solid fa-circle fa-stack-2x"></i>
+          <i class="fa-solid fa-2 fa-stack-1x fa-inverse"></i>
+        </span>
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Drive On &amp; Unload</h3>
@@ -211,7 +217,10 @@
 
     <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex flex-col items-center text-center">
       <div class="text-brand-orange text-5xl mb-4">
-        <i class="fa-solid fa-circle-3"></i>
+        <span class="fa-stack fa-2x">
+          <i class="fa-solid fa-circle fa-stack-2x"></i>
+          <i class="fa-solid fa-3 fa-stack-1x fa-inverse"></i>
+        </span>
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Get Paid—Instantly</h3>


### PR DESCRIPTION
## Summary
- fix FontAwesome icons for the 3 easy steps section by stacking circle and digits

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68609893e22c8329914b1fc8c0ea0382