### PR TITLE
Remove quick notes card

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,15 +232,13 @@
     </div>
   </div>
 
-      <div class="max-w-3xl mx-auto mt-12">
-        <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 text-brand-steel">
-          <p class="font-semibold mb-2">Quick notes</p>
-          <ul class="list-disc pl-5 mb-6">
-            <li>Photo ID required for state compliance.</li>
-            <li>Prices update throughout the day with market swings—check before you haul.</li>
-          </ul>
-          <p>Still have questions? Hit the chat bubble or call dispatch at (555) 123-SCRAP—we’ll get you sorted.</p>
-        </div>
+      <div class="max-w-3xl mx-auto mt-12 text-brand-steel">
+        <p class="font-semibold mb-2">Quick notes</p>
+        <ul class="list-disc pl-5 mb-6 text-base md:text-sm space-y-1">
+          <li>Photo ID required for state compliance.</li>
+          <li>Prices update throughout the day with market swings—check before you haul.</li>
+        </ul>
+        <p class="text-base md:text-sm">Still have questions? Hit the chat bubble or call dispatch at (555) 123-SCRAP—we’ll get you sorted.</p>
       </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- remove card from quick notes on the home page
- style quick notes inline within the section

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860999af22883298f8ea246bf886a23