### PR TITLE
Add client testimonial band

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,8 @@
   </div>
 </section>
 
+
+
 <section id="services" class="scroll-mt-16 py-20 bg-gray-100">
   <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold mb-4">Our Core Services</h2>
@@ -240,6 +242,28 @@
         </ul>
         <p class="text-base md:text-sm">Still have questions? Hit the chat bubble or call dispatch at (555) 123-SCRAP—we’ll get you sorted.</p>
       </div>
+  </div>
+</section>
+
+<!-- Rating/Client Logos Band -->
+<section id="client-band" class="bg-brand-charcoal text-white py-4 group relative overflow-hidden">
+  <div class="max-w-7xl mx-auto px-6 flex flex-wrap justify-center items-center gap-6 text-sm">
+    <div class="flex items-center gap-2 whitespace-nowrap">
+      <span class="text-yellow-400">★★★★★</span>
+      <span class="font-semibold">4.8 Google rating</span>
+    </div>
+    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
+    <div class="flex gap-4 flex-wrap justify-center items-center uppercase">
+      <span>City of Houston</span>
+      <span>XYZ Construction</span>
+      <span>Acme Manufacturing</span>
+      <span>MegaCorp</span>
+    </div>
+    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
+    <div>As seen in <em>Recycling Today</em></div>
+  </div>
+  <div id="client-testimonial" class="absolute inset-0 hidden items-center justify-center bg-white text-brand-charcoal text-center p-4 group-hover:flex">
+    <p class="max-w-xl text-sm">“Demo Yard consistently provides fast service and fair prices—our go‑to recycling partner.”</p>
   </div>
 </section>
 

--- a/script.js
+++ b/script.js
@@ -84,6 +84,17 @@ function initMenu() {
       }
     });
   }
+
+  const band = document.getElementById('client-band');
+  if (band) {
+    const testimonial = document.getElementById('client-testimonial');
+    band.addEventListener('click', () => {
+      if (testimonial) {
+        testimonial.classList.toggle('hidden');
+        testimonial.classList.toggle('flex');
+      }
+    });
+  }
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- add a full-width rating band with client logos below "3 Easy Steps"
- toggle testimonial on click and hover

## Testing
- `tidy --version` *(fails: command not found)*
- `htmlhint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609a7514c88329b4df7874d7be5dd0