### PR TITLE
Make bottom CTA a gradient banner

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -156,3 +156,8 @@ header nav a:hover::after,
   100% { background-position: 0% 50%; }
 
 }
+
+/* Contrasted banner for the bottom call to action */
+.cta-banner {
+  background: linear-gradient(90deg, var(--color-links), var(--color-success));
+}

--- a/index.html
+++ b/index.html
@@ -311,10 +311,10 @@
       <h3 class="font-semibold">E-Scrap &amp; Batteries</h3>
     </div>
 
-<section class="py-20 bg-gray-700">
-  <div class="max-w-4xl mx-auto text-center">
+<section class="py-20 cta-banner text-white text-center">
+  <div class="max-w-4xl mx-auto">
     <h2 class="text-3xl font-bold mb-6">Ready to turn scrap into cash?</h2>
-    <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
+    <a href="contact.html" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Request a Quote</a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- added `.cta-banner` gradient style for call to action sections
- updated the final "Ready to turn scrap into cash?" section to use the new banner style

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68609fe742ec83298e3cdcd4d2cc418e