### PR TITLE
Move social proof banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,25 +194,6 @@
   </div>
 </section>
 
-<!-- Rating/Client Logos Band -->
-<section id="client-band" class="bg-brand-charcoal text-white py-4 relative overflow-hidden">
-  <div class="max-w-7xl mx-auto px-6 flex flex-wrap justify-center items-center gap-6 text-sm">
-    <div class="flex items-center gap-2 whitespace-nowrap">
-      <span class="text-yellow-400">★★★★★</span>
-      <span class="font-semibold">4.8 Google rating</span>
-    </div>
-    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
-    <div class="flex gap-4 flex-wrap justify-center items-center uppercase">
-      <span>City of Houston</span>
-      <span>XYZ Construction</span>
-      <span>Acme Manufacturing</span>
-      <span>MegaCorp</span>
-    </div>
-    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
-    <div>As seen in <em>Recycling Today</em></div>
-  </div>
-</section>
-
 <section class="py-20 bg-gray-100">
   <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold mb-8">Sell Your Scrap in 3 Easy Steps</h2>
@@ -264,6 +245,24 @@
     </div>
   </div>
 
+  </div>
+</section>
+<!-- Rating/Client Logos Band -->
+<section id="client-band" class="bg-brand-charcoal text-white py-4 relative overflow-hidden">
+  <div class="max-w-7xl mx-auto px-6 flex flex-wrap justify-center items-center gap-6 text-sm">
+    <div class="flex items-center gap-2 whitespace-nowrap">
+      <span class="text-yellow-400">★★★★★</span>
+      <span class="font-semibold">4.8 Google rating</span>
+    </div>
+    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
+    <div class="flex gap-4 flex-wrap justify-center items-center uppercase">
+      <span>City of Houston</span>
+      <span>XYZ Construction</span>
+      <span>Acme Manufacturing</span>
+      <span>MegaCorp</span>
+    </div>
+    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
+    <div>As seen in <em>Recycling Today</em></div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- reposition client-logo banner further down the homepage

## Testing
- `git diff --color --unified=5`


------
https://chatgpt.com/codex/tasks/task_e_68609fcb53f88329bff216f0e44fedac