### PR TITLE
Fix CTA banner markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,6 +310,9 @@
       <h3 class="font-semibold">E-Scrap &amp; Batteries</h3>
     </div>
 
+  </div> <!-- grid -->
+</section>
+
 <section class="py-20 cta-banner text-white text-center">
   <div class="max-w-4xl mx-auto">
     <h2 class="text-3xl font-bold mb-6">Ready to turn scrap into cash?</h2>


### PR DESCRIPTION
## Summary
- close the Accepted Materials section's grid properly
- keep the ready-to-turn-scrap CTA outside the grid so it shows up correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860a16ae3a083298e3664e9418aa973