### PR TITLE
Revamp process page

### DIFF
--- a/process.html
+++ b/process.html
@@ -92,106 +92,171 @@
       <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
       <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
     </div>
-  </header>
 <main class="flex-grow">
 
-<section class="max-w-7xl mx-auto px-4 py-20">
-  <h2 class="text-4xl font-bold text-center mb-8">Process: From Pull-Up to Payout</h2>
-
-  <div class="max-w-3xl mx-auto space-y-10">
-    <div>
-      <h3 class="text-3xl font-semibold mb-2">Our Promise</h3>
-      <p class="text-gray-400 mb-4">“Ten minutes in, cash (or ACH) out.”</p>
-      <p class="text-gray-400">We’ve spent five decades refining a system that keeps traffic moving, prices transparent, and paperwork painless. Whether you’re a first-timer with two bags of cans or an industrial hauler with 20 tons of Z-Twitch, the three steps below never change—only the scale ticket does.</p>
-    </div>
-
-    <div>
-      <h3 class="text-3xl font-semibold mb-4">1&nbsp;Check Your Material — Know Before You Roll</h3>
-      <h4 class="text-xl font-semibold mt-4">Accepted for Top Dollar</h4>
-      <ul class="list-disc pl-5 text-gray-400 space-y-1">
-        <li>Copper &amp; Brass – bare bright, #1, #2, radiators, red brass fittings</li>
-        <li>Aluminum – sheet, cast, extrusions, wheels, siding, beverage cans</li>
-        <li>Steel &amp; Iron – appliances (de-fluids drained), plate &amp; structural, farm scrap</li>
-        <li>Stainless Steel – 304 &amp; 316 solids, turnings, clean tanks</li>
-        <li>Catalytic Converters – OEM, aftermarket, small engine</li>
-        <li>E-Scrap &amp; Batteries – servers, motherboards, lead-acid, lithium-ion (tape terminals)</li>
-      </ul>
-      <p class="mt-4"><a href="assets/accepted-materials.pdf" class="underline hover:text-yellow-400">Full list &amp; prep guide</a> — Download the Accepted Materials PDF for weight deductions, contamination rules, and photos of what not to bring.</p>
-      <p class="mt-2">Have mixed loads? No worries—our crew will sort and grade for you while you watch.</p>
-      <h4 class="text-xl font-semibold mt-6">Not Accepted (for your safety &amp; ours)</h4>
-      <ul class="list-disc pl-5 text-gray-400 space-y-1">
-        <li>Pressurized cylinders, sealed drums, or tanks</li>
-        <li>Tires, liquids, or haz-mat (fuel, oil, paint)</li>
-        <li>Radioactive or biomedical waste</li>
-      </ul>
-      <p class="mt-2">Need clarification? Hit the <a href="contact.html" class="underline hover:text-yellow-400">chat bubble</a> or call (555) 123-SCRAP—real humans pick up.</p>
-    </div>
-
-    <div>
-      <h3 class="text-3xl font-semibold mb-4">2&nbsp;Drive On &amp; Unload — Fast Lanes, Pro Crew</h3>
-      <h4 class="text-xl font-semibold mt-4">Arrive &amp; Weigh-In</h4>
-      <ul class="list-disc pl-5 text-gray-400 space-y-1">
-        <li>Pull onto the certified inbound truck scale.</li>
-        <li>Get a printed inbound weight ticket—this locks your tare weight.</li>
-      </ul>
-      <h4 class="text-xl font-semibold mt-6">Follow the Color-Coded Lanes</h4>
-      <ul class="list-disc pl-5 text-gray-400 space-y-1">
-        <li>Orange = Ferrous</li>
-        <li>Blue = Non-ferrous</li>
-        <li>Green = Catalytic Converters &amp; E-Scrap</li>
-      </ul>
-      <p class="mt-2">(Swipe the Yard Map below if you’re on mobile.)</p>
-      <h4 class="text-xl font-semibold mt-6">Unload &amp; Grade</h4>
-      <ul class="list-disc pl-5 text-gray-400 space-y-1">
-        <li>Our team operates forklifts, magnets, and grapple loaders so you don’t lift a thing.</li>
-        <li>Each category is graded in plain view; you’ll see the scale readout live.</li>
-      </ul>
-      <h4 class="text-xl font-semibold mt-6">Outbound Scale</h4>
-      <ul class="list-disc pl-5 text-gray-400 space-y-1">
-        <li>Empty vehicle rolls back over the scale.</li>
-        <li>Final ticket prints automatically—weight, grade, price per pound, total due.</li>
-      </ul>
-      <p class="mt-2"><strong>First-Timer Tip:</strong> Watch our 20-second Drone Fly-Over video (opens full-screen) so you know exactly where to turn, park, and exit.</p>
-    </div>
-
-    <div>
-      <h3 class="text-3xl font-semibold mb-4">3&nbsp;Get Paid — Right Here, Right Now</h3>
-      <h4 class="text-xl font-semibold mt-4">Payment Options</h4>
-      <ul class="list-disc pl-5 text-gray-400 space-y-1">
-        <li>Cash (up to state limit)</li>
-        <li>Same-Day ACH (funds hit by 7 p.m.)</li>
-        <li>Company Check (printed on-site)</li>
-      </ul>
-      <h4 class="text-xl font-semibold mt-6">Price Protection</h4>
-      <p class="text-gray-400">Lock your rate for two hours after the first weigh-in—even if markets swing.</p>
-      <h4 class="text-xl font-semibold mt-6">Live Market Ticker</h4>
-      <p class="text-gray-400">While you’re at the pay window, today’s LME and Comex highlights scroll across the screen so you can see how we set pricing in real time.</p>
-      <p class="mt-4">Need a container tomorrow? Tap <a href="contact.html" class="underline hover:text-yellow-400">Book a Roll-Off</a> and our dispatcher will confirm within 15 minutes.</p>
-    </div>
-
-    <div>
-      <h3 class="text-3xl font-semibold mb-4">Yard Map &amp; Hours</h3>
-      <p class="text-gray-400">Open&nbsp;Mon–Fri&nbsp;7&nbsp;a–5&nbsp;p · Sat&nbsp;7&nbsp;a–1&nbsp;p · Sun&nbsp;Closed<br>Address&nbsp;1234 Scrap Lane, Houston, TX 77001<br>Phone&nbsp;<a href="tel:555123SCRAP" class="underline hover:text-yellow-400">(555) 123-SCRAP</a></p>
-      <img src="assets/yard-map.svg" alt="Interactive yard map" class="my-6 mx-auto rounded-lg shadow">
-    </div>
-
-    <div>
-      <h3 class="text-3xl font-semibold mb-4">Quick FAQ</h3>
-      <p class="text-gray-400"><strong>Do I need an ID?</strong><br>Yes—state law requires a valid photo ID for non-ferrous transactions.</p>
-      <p class="text-gray-400 mt-2"><strong>How often do prices change?</strong><br>Copper &amp; aluminum adjust with the global markets, sometimes twice daily. Check the <a href="pricing.html" class="underline hover:text-yellow-400">Today’s Prices</a> link before you haul.</p>
-      <p class="text-gray-400 mt-2"><strong>Can you destroy hard drives?</strong><br>Absolutely. Data-destruction certificates available on request.</p>
-      <p class="mt-2">More questions? Check the <a href="faq.html" class="underline hover:text-yellow-400">Full FAQ</a> or call us—no bots, just scrap pros.</p>
-    </div>
-
-    <div class="text-center">
-      <h3 class="text-3xl font-semibold mb-2">Ready to Turn Scrap into Cash?</h3>
-      <p class="text-gray-400 mb-4">📞 (555) 123-SCRAP • ✉️ <a href="contact.html" class="underline hover:text-yellow-400">Request a Quote</a><br>Or pull in now—no appointment needed.</p>
-      <p class="font-semibold">“More metal. Less hassle. Better pay.”</p>
+<section id="hero" class="relative isolate flex items-center justify-center h-[80vh] text-center">
+  <video class="absolute inset-0 w-full h-full object-cover" src="assets/scale-loop.mp4" autoplay muted loop playsinline></video>
+  <div class="absolute inset-0 bg-black/60"></div>
+  <div class="relative z-10 max-w-2xl px-6">
+    <h1 class="text-4xl md:text-6xl font-extrabold text-white">From Pull-Up to Payout in 3 Easy Steps</h1>
+    <p class="mt-4 text-lg text-white">Average yard time: 10 minutes. No appointment needed.</p>
+    <div class="mt-6 flex flex-wrap justify-center gap-4">
+      <a href="#check" class="rounded-md bg-brand-orange px-4 py-2 font-semibold text-white">Check Material ↓</a>
+      <a href="#unload" class="rounded-md bg-brand-orange px-4 py-2 font-semibold text-white">Drive &amp; Unload ↓</a>
+      <a href="#paid" class="rounded-md bg-brand-orange px-4 py-2 font-semibold text-white">Get Paid ↓</a>
     </div>
   </div>
 </section>
 
+<section id="check" class="py-20">
+  <div class="max-w-6xl mx-auto px-6">
+    <h2 class="text-3xl font-bold text-center mb-8">Step 1 – Check Your Material</h2>
+    <div class="grid md:grid-cols-6 gap-4">
+      <div class="relative group aspect-square bg-gray-100 rounded-lg flex items-center justify-center">
+        <i class="fa-solid fa-bolt text-3xl text-brand-steel"></i>
+        <div class="absolute inset-0 rounded-lg bg-brand-orange/70 text-white flex items-center justify-center text-sm opacity-0 group-hover:opacity-100">$2.20‑$3/lb</div>
+      </div>
+      <div class="relative group aspect-square bg-gray-100 rounded-lg flex items-center justify-center">
+        <i class="fa-solid fa-screwdriver-wrench text-3xl text-brand-steel"></i>
+        <div class="absolute inset-0 rounded-lg bg-brand-orange/70 text-white flex items-center justify-center text-sm opacity-0 group-hover:opacity-100">$1‑$2/lb</div>
+      </div>
+      <div class="relative group aspect-square bg-gray-100 rounded-lg flex items-center justify-center">
+        <i class="fa-solid fa-car-battery text-3xl text-brand-steel"></i>
+        <div class="absolute inset-0 rounded-lg bg-brand-orange/70 text-white flex items-center justify-center text-sm opacity-0 group-hover:opacity-100">Call</div>
+      </div>
+      <div class="relative group aspect-square bg-gray-100 rounded-lg flex items-center justify-center">
+        <i class="fa-solid fa-magnet text-3xl text-brand-steel"></i>
+        <div class="absolute inset-0 rounded-lg bg-brand-orange/70 text-white flex items-center justify-center text-sm opacity-0 group-hover:opacity-100">$0.06‑$0.1/lb</div>
+      </div>
+      <div class="relative group aspect-square bg-gray-100 rounded-lg flex items-center justify-center">
+        <i class="fa-solid fa-plug text-3xl text-brand-steel"></i>
+        <div class="absolute inset-0 rounded-lg bg-brand-orange/70 text-white flex items-center justify-center text-sm opacity-0 group-hover:opacity-100">Varies</div>
+      </div>
+      <div class="relative group aspect-square bg-gray-100 rounded-lg flex items-center justify-center">
+        <i class="fa-solid fa-recycle text-3xl text-brand-steel"></i>
+        <div class="absolute inset-0 rounded-lg bg-brand-orange/70 text-white flex items-center justify-center text-sm opacity-0 group-hover:opacity-100">Market</div>
+      </div>
+    </div>
+    <p class="mt-4 text-center"><a href="materials.html" class="underline hover:text-brand-orange">View Full List</a></p>
+    <div class="mt-8 flex flex-wrap justify-center gap-2">
+      <span class="bg-zinc-200 text-xs px-2 py-1 rounded">Aerosol cans</span>
+      <span class="bg-zinc-200 text-xs px-2 py-1 rounded">Tires</span>
+      <span class="bg-zinc-200 text-xs px-2 py-1 rounded">Liquids</span>
+      <span class="bg-zinc-200 text-xs px-2 py-1 rounded">Haz-mat</span>
+    </div>
+  </div>
+</section>
+
+<section id="unload" class="py-20 bg-gray-100">
+  <div class="max-w-6xl mx-auto grid md:grid-cols-2 gap-10 items-center px-6">
+    <div>
+      <h2 class="text-3xl font-bold mb-4">Scale • Sort • Done</h2>
+      <ol class="border-l-2 border-brand-orange pl-6 space-y-6">
+        <li class="relative">
+          <span class="absolute -left-4 top-0 bg-brand-orange text-white h-6 w-6 rounded-full flex items-center justify-center text-xs">1</span>
+          Scale
+        </li>
+        <li class="relative">
+          <span class="absolute -left-4 top-0 bg-brand-orange text-white h-6 w-6 rounded-full flex items-center justify-center text-xs">2</span>
+          Lanes
+        </li>
+        <li class="relative">
+          <span class="absolute -left-4 top-0 bg-brand-orange text-white h-6 w-6 rounded-full flex items-center justify-center text-xs">3</span>
+          Ticket
+        </li>
+      </ol>
+      <div class="mt-6 flex gap-3">
+        <span class="bg-gray-200 rounded-full px-3 py-1 text-sm font-medium">97% repeat sellers</span>
+        <span class="bg-gray-200 rounded-full px-3 py-1 text-sm font-medium">≤10 min avg yard time</span>
+      </div>
+    </div>
+    <div class="text-center">
+      <div id="yardMap" class="relative mx-auto rounded-lg shadow w-full h-auto">
+        <svg viewBox="0 0 200 150" class="w-full h-auto" aria-describedby="mapDesc">
+          <desc id="mapDesc">Interactive yard map showing scale, unloading lanes and ticket office</desc>
+          <image href="assets/yard-map.svg" width="200" height="150"/>
+          <rect x="10" y="10" width="60" height="40" fill="rgba(0,0,0,0)" data-info="Scale: stop here first."/>
+          <rect x="80" y="10" width="100" height="100" fill="rgba(0,0,0,0)" data-info="Lanes: follow staff directions to unload."/>
+          <rect x="10" y="60" width="60" height="40" fill="rgba(0,0,0,0)" data-info="Ticket: get your ticket here."/>
+        </svg>
+        <div id="mapTooltip" class="hidden absolute bg-brand-orange text-white text-xs px-2 py-1 rounded pointer-events-none"></div>
+      </div>
+      <noscript>
+        <img src="assets/yard-map.svg" alt="Yard map" class="mx-auto rounded-lg shadow"/>
+      </noscript>
+      <button id="flyOverBtn" class="mt-4 text-brand-orange underline">Watch 20-sec Fly-Over</button>
+    </div>
+  </div>
+</section>
+
+<section id="paid" class="py-20">
+  <div class="max-w-6xl mx-auto grid md:grid-cols-2 gap-10 items-center px-6">
+    <div>
+      <h2 class="text-3xl font-bold mb-4">Cash, ACH, or Check—Your Choice</h2>
+      <ul class="space-y-2">
+        <li class="flex items-center gap-2"><span>💸</span> Cash (&lt;$X state limit)</li>
+        <li class="flex items-center gap-2"><span>🏦</span> Same-Day ACH</li>
+        <li class="flex items-center gap-2"><span>📝</span> Company Check</li>
+      </ul>
+      <div class="overflow-hidden whitespace-nowrap mt-6 bg-gray-100 rounded-lg">
+        <div class="price-ticker py-2 px-4">Copper $2.50/lb — Brass $1.80/lb — Aluminum $0.80/lb</div>
+      </div>
+      <button class="mt-6 rounded-md bg-brand-orange px-6 py-3 font-semibold text-white shadow hover:opacity-90 transition">Lock My Price</button>
+    </div>
+    <img src="assets/hero.jpg" alt="Payment" class="rounded-lg shadow">
+  </div>
+</section>
+
+<section class="py-20 bg-gray-100">
+  <div class="max-w-3xl mx-auto px-6">
+    <h2 class="text-3xl font-bold text-center mb-8">Quick FAQ</h2>
+    <div class="space-y-4">
+      <details open class="bg-white rounded-lg p-4">
+        <summary class="cursor-pointer font-medium">Do I need an ID?</summary>
+        <p class="mt-2 text-gray-500">Yes—state law requires a valid photo ID for non-ferrous transactions.</p>
+      </details>
+      <details class="bg-white rounded-lg p-4">
+        <summary class="cursor-pointer font-medium">How often do prices change?</summary>
+        <p class="mt-2 text-gray-500">Markets update daily. Check our pricing page for the latest numbers.</p>
+      </details>
+      <details class="bg-white rounded-lg p-4">
+        <summary class="cursor-pointer font-medium">Hazardous materials?</summary>
+        <p class="mt-2 text-gray-500">We cannot accept fuel, oil, or other haz‑mat items.</p>
+      </details>
+      <details class="bg-white rounded-lg p-4">
+        <summary class="cursor-pointer font-medium">Large loads?</summary>
+        <p class="mt-2 text-gray-500">Call ahead so we can direct you to the right lane on arrival.</p>
+      </details>
+      <details class="bg-white rounded-lg p-4">
+        <summary class="cursor-pointer font-medium">Price updates?</summary>
+        <p class="mt-2 text-gray-500">Sign up for alerts or watch the ticker above for today’s top metals.</p>
+      </details>
+    </div>
+    <div class="text-center mt-6">
+      <a href="https://wa.me/15551234567" class="underline text-brand-orange font-semibold">Still have questions? Chat with us</a>
+    </div>
+  </div>
+</section>
+
+<section class="bg-zinc-900 text-white text-center py-12">
+  <p class="text-2xl font-bold mb-2">Ready to roll in or need a roll-off?</p>
+  <p class="text-lg">📞 (555) 123-SCRAP &nbsp; • &nbsp; ✉️ <a href="contact.html" class="underline">Request a Quote</a></p>
+</section>
+
 </main>
+
+<div id="stickyCTA" class="fixed bottom-0 inset-x-0 bg-brand-orange text-white flex items-center justify-between px-4 py-3 shadow-lg hidden">
+  <span>Turn scrap into cash today.</span>
+  <a href="#quote" class="font-semibold underline">Get a Quote</a>
+  <button aria-label="Close" class="ml-3">×</button>
+</div>
+
+<div id="flyOverModal" class="fixed inset-0 bg-black/80 items-center justify-center hidden">
+  <div class="relative w-full max-w-2xl mx-auto p-4">
+    <button aria-label="Close" class="absolute top-2 right-2 text-white text-2xl">×</button>
+    <video src="assets/fly-over.mp4" controls class="w-full h-auto"></video>
+  </div>
+</div>
 <!-- ── Footer ──────────────────────────────────────────────── -->
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>

--- a/script.js
+++ b/script.js
@@ -87,9 +87,67 @@ function initMenu() {
 
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initMenu);
-} else {
-  initMenu();
+
+function initStickyCTA() {
+  const cta = document.getElementById('stickyCTA');
+  if (!cta) return;
+  const close = cta.querySelector('button[aria-label="Close"]');
+  if (close) close.addEventListener('click', () => cta.classList.add('hidden'));
+  const showAt = 0.8;
+  const onScroll = () => {
+    const progress = (window.scrollY + window.innerHeight) / document.documentElement.scrollHeight;
+    if (progress >= showAt) {
+      cta.classList.remove('hidden');
+      window.removeEventListener('scroll', onScroll);
+    }
+  };
+  window.addEventListener('scroll', onScroll);
 }
 
+function initFlyOver() {
+  const btn = document.getElementById('flyOverBtn');
+  const modal = document.getElementById('flyOverModal');
+  if (!btn || !modal) return;
+  const video = modal.querySelector('video');
+  const close = modal.querySelector('button[aria-label="Close"]');
+  const open = () => { modal.classList.remove('hidden'); };
+  const hide = () => { modal.classList.add('hidden'); if (video) video.pause(); };
+  btn.addEventListener('click', open);
+  if (close) close.addEventListener('click', hide);
+}
+
+function initYardMap() {
+  const map = document.getElementById('yardMap');
+  const tooltip = document.getElementById('mapTooltip');
+  if (!map || !tooltip) return;
+  const zones = map.querySelectorAll('rect');
+  zones.forEach(zone => {
+    zone.addEventListener('mouseenter', (e) => {
+      const info = zone.getAttribute('data-info');
+      if (!info) return;
+      tooltip.textContent = info;
+      tooltip.style.left = `${e.offsetX + 10}px`;
+      tooltip.style.top = `${e.offsetY + 10}px`;
+      tooltip.classList.remove('hidden');
+    });
+    zone.addEventListener('mouseleave', () => {
+      tooltip.classList.add('hidden');
+    });
+    zone.addEventListener('click', () => {
+      tooltip.classList.add('hidden');
+    });
+  });
+}
+
+function initPage() {
+  initMenu();
+  initStickyCTA();
+  initFlyOver();
+  initYardMap();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initPage);
+} else {
+  initPage();
+}


### PR DESCRIPTION
## Summary
- redesign Process page with hero video, interactive sections and sticky CTA
- add interactive SVG yard map and tooltip
- remove placeholder video assets per repo rules

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860a5546d188329a605c2a073862e93