### PR TITLE
Improve homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,9 +116,9 @@
          class="rounded-md bg-brand-orange px-8 py-3 text-white font-semibold shadow-lg hover:opacity-90 transition">
         Request a Quote
       </a>
-      <a href="services.html"
-         class="rounded-md bg-white px-8 py-3 text-brand-orange font-semibold shadow-lg hover:bg-gray-100 transition">
-        Our Services
+      <a href="#services"
+         class="inline-block rounded-md border border-white px-6 py-3 text-white hover:bg-white/10 transition">
+        Our Services ↓
       </a>
     </div>
   </div>
@@ -136,7 +136,7 @@
 
   <div class="mt-16 grid gap-8 md:grid-cols-3 max-w-6xl mx-auto px-6">
     <!-- card -->
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
+    <a href="services.html#buying" class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center hover:cursor-pointer">
       <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
         <i class="fa-solid fa-magnet"></i>
       </div>
@@ -144,8 +144,8 @@
         <h3 class="font-semibold text-lg mb-2">Ferrous & Non‑Ferrous Buying</h3>
         <p class="text-base md:text-sm text-brand-steel">Competitive pricing on steel, aluminum, copper, brass, and more.</p>
       </div>
-    </div>
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
+    </a>
+    <a href="services.html#containers" class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center hover:cursor-pointer">
       <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
         <i class="fa-solid fa-dumpster"></i>
       </div>
@@ -153,8 +153,8 @@
         <h3 class="font-semibold text-lg mb-2">Industrial Container Service</h3>
         <p class="text-base md:text-sm text-brand-steel">Scheduled roll‑off swaps to keep your operation moving.</p>
       </div>
-    </div>
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
+    </a>
+    <a href="services.html#demo" class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center hover:cursor-pointer">
       <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
         <i class="fa-solid fa-broom"></i>
       </div>
@@ -162,7 +162,7 @@
         <h3 class="font-semibold text-lg mb-2">Demolition & Clean‑Up</h3>
         <p class="text-base md:text-sm text-brand-steel">Safe, insured crews for on‑site dismantling and hauling.</p>
       </div>
-    </div>
+    </a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- style 'Our Services' button like the About page hero button
- scroll to the Core Services section
- link each service card to its details on the Services page

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6860a97ea45083299ac972058c8cfbc3