### PR TITLE
Fix about page card styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -171,7 +171,7 @@
   <section class="py-20">
     <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-4 gap-8">
 
-      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm p-8 flex items-center md:flex-col md:text-center">
+      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
 
         <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4"><i class="fa-regular fa-clock"></i></div>
         <div class="text-left md:text-center">
@@ -180,7 +180,7 @@
         </div>
       </div>
 
-      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm p-8 flex items-center md:flex-col md:text-center">
+      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
         <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4"><i class="fa-solid fa-tags"></i></div>
         <div class="text-left md:text-center">
           <h3 class="font-semibold text-lg mb-2">Certified Accuracy</h3>
@@ -188,7 +188,7 @@
         </div>
       </div>
 
-      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm p-8 flex items-center md:flex-col md:text-center">
+      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
 
         <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4"><i class="fa-solid fa-recycle"></i></div>
         <div class="text-left md:text-center">
@@ -197,7 +197,7 @@
         </div>
       </div>
 
-      <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
+      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
 
         <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4"><i class="fa-solid fa-handshake"></i></div>
         <div class="text-left md:text-center">


### PR DESCRIPTION
## Summary
- update all cards in the About page to share the same orange background and hover animation

## Testing
- `git diff --staged`


------
https://chatgpt.com/codex/tasks/task_e_6860a9f128bc8329acde2dd199d5ab62