### PR TITLE
Remove sticky footers from pages

### DIFF
--- a/process.html
+++ b/process.html
@@ -245,11 +245,6 @@
 
 </main>
 
-<div id="stickyCTA" class="fixed bottom-0 inset-x-0 bg-brand-orange text-white flex items-center justify-between px-4 py-3 shadow-lg hidden">
-  <span>Turn scrap into cash today.</span>
-  <a href="#quote" class="font-semibold underline">Get a Quote</a>
-  <button aria-label="Close" class="ml-3">×</button>
-</div>
 
 <div id="flyOverModal" class="fixed inset-0 bg-black/80 items-center justify-center hidden">
   <div class="relative w-full max-w-2xl mx-auto p-4">

--- a/script.js
+++ b/script.js
@@ -87,20 +87,6 @@ function initMenu() {
     aosEls.forEach(el => aosObserver.observe(el));
   }
 
-  const quoteBar = document.getElementById('quoteBar');
-  if (quoteBar) {
-    const close = quoteBar.querySelector('button');
-    if (close) {
-      close.addEventListener('click', () => quoteBar.classList.add('hidden'));
-    }
-    const onScroll = () => {
-      const depth = window.scrollY / (document.body.scrollHeight - window.innerHeight);
-      if (depth > 0.75) {
-        quoteBar.classList.remove('hidden');
-      }
-    };
-    window.addEventListener('scroll', onScroll);
-  }
 
   const homeBtn = document.getElementById('homeButton');
   if (homeBtn) {
@@ -116,21 +102,6 @@ function initMenu() {
 }
 
 
-function initStickyCTA() {
-  const cta = document.getElementById('stickyCTA');
-  if (!cta) return;
-  const close = cta.querySelector('button[aria-label="Close"]');
-  if (close) close.addEventListener('click', () => cta.classList.add('hidden'));
-  const showAt = 0.8;
-  const onScroll = () => {
-    const progress = (window.scrollY + window.innerHeight) / document.documentElement.scrollHeight;
-    if (progress >= showAt) {
-      cta.classList.remove('hidden');
-      window.removeEventListener('scroll', onScroll);
-    }
-  };
-  window.addEventListener('scroll', onScroll);
-}
 
 function initFlyOver() {
   const btn = document.getElementById('flyOverBtn');
@@ -169,7 +140,6 @@ function initYardMap() {
 
 function initPage() {
   initMenu();
-  initStickyCTA();
   initFlyOver();
   initYardMap();
 }

--- a/services.html
+++ b/services.html
@@ -251,10 +251,6 @@
 
 </main>
 
-<div id="quoteBar" class="hidden fixed bottom-0 left-0 right-0 bg-brand-orange text-white py-3 px-6 justify-between items-center shadow-xl">
-  <span>Ready to book a container or price your load? → 📞 (555) 123-SCRAP / ✉️ <a href="contact.html" class="underline">Request Quote</a></span>
-  <button aria-label="Dismiss" class="ml-4 text-xl">&times;</button>
-</div>
 
 <!-- Footer -->
 <footer class="bg-white py-8 text-center text-xs text-gray-400">


### PR DESCRIPTION
## Summary
- strip quote bar from services page
- remove sticky CTA from the process page
- drop JS code that managed these footers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860aa175ee08329a5bc3234c5568057