### PR TITLE
Fix mobile layout for roll-off CTAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
 <section class="py-20 bg-brand-charcoal text-white text-center">
   <div class="max-w-4xl mx-auto">
     <h2 class="text-3xl font-bold mb-6">Need a roll-off tomorrow?</h2>
-    <div class="flex flex-col sm:flex-row justify-center gap-4">
+    <div class="flex flex-row flex-wrap justify-center gap-4">
       <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Book a Container</a>
       <a href="tel:555123SCRAP" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Call Dispatch</a>
     </div>


### PR DESCRIPTION
## Summary
- ensure the "Need a roll-off?" call to action buttons stay side by side even on mobile

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68612795ac788329a226a1d498f5c5c3