### PR TITLE
Reorder social proof

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,24 +123,6 @@
     </div>
   </div>
 </section>
-<!-- Rating/Client Logos Band -->
-<section id="client-band" class="bg-brand-charcoal text-white py-8 relative overflow-hidden">
-  <div class="max-w-7xl mx-auto px-6 flex flex-wrap justify-center items-center gap-6 text-sm">
-    <div class="flex items-center gap-2 whitespace-nowrap">
-      <span class="text-yellow-400">★★★★★</span>
-      <span class="font-semibold">4.8 Google rating</span>
-    </div>
-    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
-    <div class="flex gap-4 flex-wrap justify-center items-center uppercase">
-      <span>City of Houston</span>
-      <span>XYZ Construction</span>
-      <span>Acme Manufacturing</span>
-      <span>MegaCorp</span>
-    </div>
-    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
-    <div>As seen in <em>Recycling Today</em></div>
-  </div>
-</section>
 
 
 
@@ -184,6 +166,24 @@
   </div>
 </section>
 
+<!-- Rating/Client Logos Band -->
+<section id="client-band" class="bg-brand-charcoal text-white py-8 relative overflow-hidden">
+  <div class="max-w-7xl mx-auto px-6 flex flex-wrap justify-center items-center gap-6 text-sm">
+    <div class="flex items-center gap-2 whitespace-nowrap">
+      <span class="text-yellow-400">★★★★★</span>
+      <span class="font-semibold">4.8 Google rating</span>
+    </div>
+    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
+    <div class="flex gap-4 flex-wrap justify-center items-center uppercase">
+      <span>City of Houston</span>
+      <span>XYZ Construction</span>
+      <span>Acme Manufacturing</span>
+      <span>MegaCorp</span>
+    </div>
+    <span class="hidden sm:inline-block border-l border-white/30 h-4"></span>
+    <div>As seen in <em>Recycling Today</em></div>
+  </div>
+</section>
 
 <section class="stats-gradient py-20">
   <div class="max-w-5xl mx-auto px-4 grid md:grid-cols-3 gap-10 text-center text-gray-900 font-extrabold">


### PR DESCRIPTION
## Summary
- move the client-band social proof section below the core services on home page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68612d34ff5483299daaf90dba511247