### PR TITLE
Change scrap yard step icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,11 +212,8 @@
 
   <div class="mt-16 grid gap-8 md:grid-cols-3 max-w-6xl mx-auto px-6">
     <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex flex-col items-center text-center">
-      <div class="text-brand-orange text-5xl mb-4">
-        <span class="fa-stack fa-2x">
-          <i class="fa-solid fa-circle fa-stack-2x"></i>
-          <i class="fa-solid fa-1 fa-stack-1x fa-inverse"></i>
-        </span>
+      <div class="text-brand-orange text-4xl mb-4">
+        <i class="fa-solid fa-list-check"></i>
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Check Your Material</h3>
@@ -225,11 +222,8 @@
     </div>
 
     <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex flex-col items-center text-center">
-      <div class="text-brand-orange text-5xl mb-4">
-        <span class="fa-stack fa-2x">
-          <i class="fa-solid fa-circle fa-stack-2x"></i>
-          <i class="fa-solid fa-2 fa-stack-1x fa-inverse"></i>
-        </span>
+      <div class="text-brand-orange text-4xl mb-4">
+        <i class="fa-solid fa-truck"></i>
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Drive On &amp; Unload</h3>
@@ -238,11 +232,8 @@
     </div>
 
     <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex flex-col items-center text-center">
-      <div class="text-brand-orange text-5xl mb-4">
-        <span class="fa-stack fa-2x">
-          <i class="fa-solid fa-circle fa-stack-2x"></i>
-          <i class="fa-solid fa-3 fa-stack-1x fa-inverse"></i>
-        </span>
+      <div class="text-brand-orange text-4xl mb-4">
+        <i class="fa-solid fa-money-bill-wave"></i>
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Get Paid—Instantly</h3>


### PR DESCRIPTION
## Summary
- replace numbered icons with icons that match each step
- slightly reduce icon size for a cleaner look

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68613ec765f88329bca7c7517fa2601e