### PR TITLE
Improve 3-step section visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,24 +211,24 @@
   </div>
 
   <div class="mt-16 grid gap-8 md:grid-cols-3 max-w-6xl mx-auto px-6">
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-start gap-4 md:flex-col md:items-center md:text-center">
-      <div class="relative flex-shrink-0 mb-4 md:mb-0">
-        <span class="text-4xl font-black text-brand-orange">1</span>
-        <svg class="absolute inset-0 w-10 h-10 text-brand-steel translate-x-1 translate-y-1 pointer-events-none" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-start gap-4">
+      <div class="relative flex-shrink-0 mb-4 md:mb-0" data-aos="fade-up" data-aos-delay="0">
+        <span class="text-5xl font-bold text-[#FF6A00]">1</span>
+        <svg class="absolute inset-0 w-6 h-6 text-[#555] opacity-60 translate-x-1 translate-y-1 pointer-events-none" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
           <path fill-rule="evenodd" d="M7.502 6h7.128A3.375 3.375 0 0 1 18 9.375v9.375a3 3 0 0 0 3-3V6.108c0-1.505-1.125-2.811-2.664-2.94a48.972 48.972 0 0 0-.673-.05A3 3 0 0 0 15 1.5h-1.5a3 3 0 0 0-2.663 1.618c-.225.015-.45.032-.673.05C8.662 3.295 7.554 4.542 7.502 6ZM13.5 3A1.5 1.5 0 0 0 12 4.5h4.5A1.5 1.5 0 0 0 15 3h-1.5Z" clip-rule="evenodd"/>
           <path fill-rule="evenodd" d="M3 9.375C3 8.339 3.84 7.5 4.875 7.5h9.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 0 1 3 20.625V9.375ZM6 12a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V12Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 15a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V15Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 18a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V18Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75Z" clip-rule="evenodd"/>
         </svg>
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Check Your Material</h3>
-        <p class="text-base md:text-sm text-brand-steel">We accept Copper, Brass, Aluminum (sheet, cast &amp; cans), Steel, Iron, Stainless Steel, Catalytic Converters, E-Scrap, Batteries, &amp; more! <br><br>Need the full list? Tap <a href="assets/accepted-materials.pdf" class="animated-link font-bold" target="_blank">View All Materials</a> to see every item we take—and the few we don’t (haz-mat, sealed tanks, liquids).</p>
+        <p class="text-sm leading-relaxed max-w-prose text-brand-steel">We accept Copper, Brass, Aluminum (sheet, cast &amp; cans), Steel, Iron, Stainless Steel, Catalytic Converters, E-Scrap, Batteries, &amp; more! <br><br>Need the full list? Tap <a href="assets/accepted-materials.pdf" class="animated-link font-bold" target="_blank">View All Materials</a> to see every item we take—and the few we don’t (haz-mat, sealed tanks, liquids).</p>
       </div>
     </div>
 
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-start gap-4 md:flex-col md:items-center md:text-center">
-      <div class="relative flex-shrink-0 mb-4 md:mb-0">
-        <span class="text-4xl font-black text-brand-orange">2</span>
-        <svg class="absolute inset-0 w-10 h-10 text-brand-steel translate-x-1 translate-y-1 pointer-events-none" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-start gap-4">
+      <div class="relative flex-shrink-0 mb-4 md:mb-0" data-aos="fade-up" data-aos-delay="80">
+        <span class="text-5xl font-bold text-[#FF6A00]">2</span>
+        <svg class="absolute inset-0 w-6 h-6 text-[#555] opacity-60 translate-x-1 translate-y-1 pointer-events-none" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
           <path d="M3.375 4.5C2.339 4.5 1.5 5.34 1.5 6.375V13.5h12V6.375c0-1.036-.84-1.875-1.875-1.875h-8.25ZM13.5 15h-12v2.625c0 1.035.84 1.875 1.875 1.875h.375a3 3 0 1 1 6 0h3a.75.75 0 0 0 .75-.75V15Z"/>
           <path d="M8.25 19.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0ZM15.75 6.75a.75.75 0 0 0-.75.75v11.25c0 .087.015.17.042.248a3 3 0 0 1 5.958.464c.853-.175 1.522-.935 1.464-1.883a18.659 18.659 0 0 0-3.732-10.104 1.837 1.837 0 0 0-1.47-.725H15.75Z"/>
           <path d="M19.5 19.5a1.5 1.5 0 1 0-3 0 1.5 1.5 0 0 0 3 0Z"/>
@@ -236,14 +236,14 @@
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Drive On &amp; Unload</h3>
-        <p class="text-base md:text-sm text-brand-steel">Roll onto our calibrated truck scale, grab a yard pass, and follow the clearly-marked lanes. Our crew will grade, sort, and unload for you—so you’re back on the road fast. <br><br>First time here? Tap <a href="https://maps.google.com" target="_blank" class="animated-link font-bold">Google Maps</a> directions or call us at xxx.xxx.xxxx to get more info.</p>
+        <p class="text-sm leading-relaxed max-w-prose text-brand-steel">Roll onto our calibrated truck scale, grab a yard pass, and follow the clearly-marked lanes. Our crew will grade, sort, and unload for you—so you’re back on the road fast. <br><br>First time here? Tap <a href="https://maps.google.com" target="_blank" class="animated-link font-bold">Google Maps</a> directions or call us at xxx.xxx.xxxx to get more info.</p>
       </div>
     </div>
 
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-start gap-4 md:flex-col md:items-center md:text-center">
-      <div class="relative flex-shrink-0 mb-4 md:mb-0">
-        <span class="text-4xl font-black text-brand-orange">3</span>
-        <svg class="absolute inset-0 w-10 h-10 text-brand-steel translate-x-1 translate-y-1 pointer-events-none" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-start gap-4">
+      <div class="relative flex-shrink-0 mb-4 md:mb-0" data-aos="fade-up" data-aos-delay="160">
+        <span class="text-5xl font-bold text-[#FF6A00]">3</span>
+        <svg class="absolute inset-0 w-6 h-6 text-[#555] opacity-60 translate-x-1 translate-y-1 pointer-events-none" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 7.5a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Z"/>
           <path fill-rule="evenodd" d="M1.5 4.875C1.5 3.839 2.34 3 3.375 3h17.25c1.035 0 1.875.84 1.875 1.875v9.75c0 1.036-.84 1.875-1.875 1.875H3.375A1.875 1.875 0 0 1 1.5 14.625v-9.75ZM8.25 9.75a3.75 3.75 0 1 1 7.5 0 3.75 3.75 0 0 1-7.5 0ZM18.75 9a.75.75 0 0 0-.75.75v.008c0 .414.336.75.75.75h.008a.75.75 0 0 0 .75-.75V9.75a.75.75 0 0 0-.75-.75h-.008ZM4.5 9.75A.75.75 0 0 1 5.25 9h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V9.75Z" clip-rule="evenodd"/>
           <path d="M2.25 18a.75.75 0 0 0 0 1.5c5.4 0 10.63.722 15.6 2.075 1.19.324 2.4-.558 2.4-1.82V18.75a.75.75 0 0 0-.75-.75H2.25Z"/>
@@ -251,7 +251,7 @@
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Get Paid—Instantly</h3>
-        <p class="text-base md:text-sm text-brand-steel">Watch your weight ticket print, then choose Cash, ACH, or Check on the spot. A live price ticker shows today’s top three metals while you wait.</p>
+        <p class="text-sm leading-relaxed max-w-prose text-brand-steel">Watch your weight ticket print, then choose Cash, ACH, or Check on the spot. A live price ticker shows today’s top three metals while you wait.</p>
         <div class="mt-8 text-center">
           <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition">Request a Quote</a>
         </div>


### PR DESCRIPTION
## Summary
- adjust 3-step card layout classes
- tweak number/ icon styling
- add fade-up animations with delay
- refine copy text styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861441ff26c83298acc8fb6a01fbdd7