### PR TITLE
Add in-page materials button

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Check Your Material</h3>
-        <p class="text-sm leading-relaxed max-w-prose text-brand-steel">We accept Copper, Brass, Aluminum (sheet, cast &amp; cans), Steel, Iron, Stainless Steel, Catalytic Converters, E-Scrap, Batteries, &amp; more! <br><br>Need the full list? Tap <a href="assets/accepted-materials.pdf" class="animated-link font-bold" target="_blank">View All Materials</a> to see every item we take—and the few we don’t (haz-mat, sealed tanks, liquids).</p>
+        <p class="text-sm leading-relaxed max-w-prose text-brand-steel">We accept Copper, Brass, Aluminum (sheet, cast &amp; cans), Steel, Iron, Stainless Steel, Catalytic Converters, E-Scrap, Batteries, &amp; more!<br><br><a href="#materials" class="inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow hover:opacity-90 transition">All Materials ⬇️</a></p>
       </div>
     </div>
 
@@ -256,7 +256,7 @@
   </div>
 </section>
 
-<section class="py-20 bg-gray-100">
+<section id="materials" class="py-20 bg-gray-100">
   <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold mb-8">Accepted Materials</h2>
     <p class="text-brand-steel mb-12">These common items bring the best rates.</p>


### PR DESCRIPTION
## Summary
- update step 1 text in three step section with new button linking to materials section
- anchor the Accepted Materials section for in-page navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686158f550348329a032240d93478f27