### PR TITLE
Fix Drive On & Unload card text

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
       </div>
       <div>
         <h3 class="font-semibold text-lg mb-2">Drive On &amp; Unload</h3>
-        <p class="text-sm leading-relaxed max-w-prose text-brand-steel">Roll onto our calibrated truck scale, grab a yard pass, and follow the clearly-marked lanes. Our crew will grade, sort, and unload for you—so you’re back on the road fast. <br><br>First time here? Tap <a href="https://maps.google.com" target="_blank" class="animated-link font-bold">Google Maps</a> directions or call us at xxx.xxx.xxxx to get more info.</p>
+        <p class="text-sm leading-relaxed max-w-prose text-brand-steel">Roll onto our calibrated truck scale, grab a yard pass, and follow the clearly-marked lanes. Our crew will grade, sort, and unload for you—so you’re back on the road fast. </p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- remove the second paragraph from the Drive On & Unload step on the home page

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861591937848329ac957165d9a95cd2