### PR TITLE
Add fade-up animation to service icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
   <div class="mt-16 grid gap-8 md:grid-cols-3 max-w-6xl mx-auto px-6">
     <!-- card -->
     <a href="services.html#buying" class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center hover:cursor-pointer">
-      <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
+      <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4" data-aos="fade-up" data-aos-delay="0">
         <i class="fa-solid fa-magnet"></i>
       </div>
       <div class="text-left md:text-center">
@@ -146,7 +146,7 @@
       </div>
     </a>
     <a href="services.html#containers" class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center hover:cursor-pointer">
-      <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
+      <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4" data-aos="fade-up" data-aos-delay="80">
         <i class="fa-solid fa-dumpster"></i>
       </div>
       <div class="text-left md:text-center">
@@ -155,7 +155,7 @@
       </div>
     </a>
     <a href="services.html#demo" class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center hover:cursor-pointer">
-      <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
+      <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4" data-aos="fade-up" data-aos-delay="160">
         <i class="fa-solid fa-broom"></i>
       </div>
       <div class="text-left md:text-center">


### PR DESCRIPTION
## Summary
- animate service icons with `data-aos` fade-up attributes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861597520108329b60abefa973488d4