### PR TITLE
Add header to about timeline

### DIFF
--- a/about.html
+++ b/about.html
@@ -111,6 +111,7 @@
   <!-- Story Timeline -->
   <section id="timeline" class="py-20">
     <div class="max-w-6xl mx-auto px-6">
+      <h2 class="text-3xl font-bold mb-8 text-center">Our Story</h2>
       <ul class="relative flex flex-col md:grid md:grid-cols-4 gap-10">
         <li class="relative">
           <div class="pl-6">


### PR DESCRIPTION
## Summary
- add "Our Story" section header in about page timeline

## Testing
- `npx --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616e4c17188329ab0d9ec09f8f4327