### PR TITLE
Add Visit Us Today section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,6 +304,21 @@
   </div> <!-- grid -->
 </section>
 
+  <section class="py-20">
+    <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-10 items-center">
+      <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm overflow-hidden">
+        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3105.0618258223353!2d-77.03171872383582!3d38.89970147172352!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89b7b7bee1b5b123%3A0x5026809f2561b278!2sRecycled%20Materials%20Association!5e0!3m2!1sen!2sus!4v1751164589301!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade" class="w-full"></iframe>
+      </div>
+        <div>
+          <h2 class="text-3xl font-bold mb-4">Visit Us Today</h2>
+          <p class="text-lg mb-2"><strong>Hours:</strong> Mon&ndash;Fri 8am&ndash;5pm</p>
+          <p class="text-lg mb-2"><strong>Address:</strong> 123 Demo Road, Demo City, NY&nbsp;12345</p>
+          <p class="text-lg mb-2"><strong>Phone:</strong> <a href="tel:5551234567" class="text-brand-orange hover:underline">555-123-4567</a></p>
+          <p class="text-lg"><strong>Email:</strong> <a href="mailto:info@demoyard.com" class="text-brand-orange hover:underline">info@demoyard.com</a></p>
+        </div>
+    </div>
+  </section>
+
 <section class="py-20 cta-banner text-white text-center">
   <div class="max-w-4xl mx-auto">
     <h2 class="text-3xl font-bold mb-6">Ready to turn scrap into cash?</h2>


### PR DESCRIPTION
## Summary
- include the "Visit Us Today" map/info block from About page on Homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68616f4da5e48329909b59edc7214d07