### PR TITLE
Trigger navbar title animation when logo hovered

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -128,6 +128,14 @@ header nav a.text-yellow-400:hover {
   transform: scaleX(1);
 }
 
+/* Hovering over the entire home button also triggers the underline */
+#homeButton:hover .animated-link::after {
+  transform: scaleX(1);
+}
+#homeButton:hover .animated-link {
+  color: currentColor !important;
+}
+
 header nav a::after,
 #mobileMenu a:not(.bg-yellow-500)::after {
   content: '';


### PR DESCRIPTION
## Summary
- allow hovering over the navbar logo to trigger the underline animation for the site name

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686170011b208329b061ca148dbd2981