### PR TITLE
Fix brand underline offset

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -115,7 +115,7 @@ header nav a.text-yellow-400:hover {
   content: '';
   position: absolute;
   left: 0;
-  bottom: -2px;
+  bottom: 0;
   width: 100%;
   height: 2px;
   background-color: var(--color-links);


### PR DESCRIPTION
## Summary
- adjust the `.animated-link::after` positioning so that the animated underline aligns with the bottom of the logo icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686170b127808329a3485972fbae3967