### PR TITLE
Move CTA above visit section

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,12 @@
 
   </div> <!-- grid -->
 </section>
+<section class="py-20 cta-banner text-white text-center">
+  <div class="max-w-4xl mx-auto">
+    <h2 class="text-3xl font-bold mb-6">Ready to turn scrap into cash?</h2>
+    <a href="contact.html" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Request a Quote</a>
+  </div>
+</section>
 
   <section class="py-20">
     <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-10 items-center">
@@ -318,13 +324,6 @@
         </div>
     </div>
   </section>
-
-<section class="py-20 cta-banner text-white text-center">
-  <div class="max-w-4xl mx-auto">
-    <h2 class="text-3xl font-bold mb-6">Ready to turn scrap into cash?</h2>
-    <a href="contact.html" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Request a Quote</a>
-  </div>
-</section>
 
 </main>
 <!-- ── Footer ──────────────────────────────────────────────── -->


### PR DESCRIPTION
## Summary
- reorder the home page so the "Ready to turn scrap into cash?" CTA appears before the "Visit Us Today" section

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6861720ec7048329988d90a152fef025