### PR TITLE
Add demo CTA to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,6 +326,17 @@
   </div>
 </section>
 
+  <!-- Scrapyard Sites CTA -->
+  <section class="py-20 bg-gray-100 text-center">
+    <div class="max-w-3xl mx-auto px-6">
+      <p class="text-xl mb-6">If this digital experience matches the service you want on the scale deck, let’s launch yours next.</p>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Book a Demo</a>
+        <a href="https://scrapyardsites.com" target="_blank" rel="noopener" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Visit ScrapyardSites.com</a>
+      </div>
+    </div>
+  </section>
+
 </main>
 <!-- ── Footer ──────────────────────────────────────────────── -->
 <footer class="bg-white py-8 text-center text-xs text-gray-400">


### PR DESCRIPTION
## Summary
- reuse the Scrapyard Sites demo CTA from About Us
- place it above the footer on `index.html`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861723812b08329a27a18f712f06988