### PR TITLE
Fix navbar brand underline alignment

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -115,7 +115,7 @@ header nav a.text-yellow-400:hover {
   content: '';
   position: absolute;
   left: 0;
-  bottom: 0;
+  bottom: -2px;
   width: 100%;
   height: 2px;
   background-color: var(--color-links);


### PR DESCRIPTION
## Summary
- tweak `.animated-link::after` rule so underline sits slightly below the navbar title

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6861727f8504832984b0c1aad30d4039