### PR TITLE
Add CTA section across site

### DIFF
--- a/accepted-materials.html
+++ b/accepted-materials.html
@@ -119,6 +119,17 @@
         </div>
         <h3 class="font-semibold">E-Scrap &amp; Batteries</h3>
       </div>
+  </div>
+  </section>
+
+  <!-- Scrapyard Sites CTA -->
+  <section class="py-20 bg-gray-100 text-center">
+    <div class="max-w-3xl mx-auto px-6">
+      <p class="text-xl mb-6">If this digital experience matches the service you want on the scale deck, let’s launch yours next.</p>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Book a Demo</a>
+        <a href="https://scrapyardsites.com" target="_blank" rel="noopener" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Visit ScrapyardSites.com</a>
+      </div>
     </div>
   </section>
 </main>

--- a/contact.html
+++ b/contact.html
@@ -121,6 +121,17 @@
   </form>
 </section>
 
+  <!-- Scrapyard Sites CTA -->
+  <section class="py-20 bg-gray-100 text-center">
+    <div class="max-w-3xl mx-auto px-6">
+      <p class="text-xl mb-6">If this digital experience matches the service you want on the scale deck, let’s launch yours next.</p>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Book a Demo</a>
+        <a href="https://scrapyardsites.com" target="_blank" rel="noopener" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Visit ScrapyardSites.com</a>
+      </div>
+    </div>
+  </section>
+
 </main>
 <!-- ── Footer ──────────────────────────────────────────────── -->
 <footer class="bg-white py-8 text-center text-xs text-gray-400">

--- a/faq.html
+++ b/faq.html
@@ -117,6 +117,17 @@
   </div>
 </section>
 
+  <!-- Scrapyard Sites CTA -->
+  <section class="py-20 bg-gray-100 text-center">
+    <div class="max-w-3xl mx-auto px-6">
+      <p class="text-xl mb-6">If this digital experience matches the service you want on the scale deck, let’s launch yours next.</p>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Book a Demo</a>
+        <a href="https://scrapyardsites.com" target="_blank" rel="noopener" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Visit ScrapyardSites.com</a>
+      </div>
+    </div>
+  </section>
+
 </main>
 <!-- ── Footer ──────────────────────────────────────────────── -->
 <footer class="bg-white py-8 text-center text-xs text-gray-400">

--- a/our-team.html
+++ b/our-team.html
@@ -97,6 +97,17 @@
         <h3 class="font-semibold">Riley</h3>
         <p class="text-sm text-brand-steel">Customer Service</p>
       </div>
+  </div>
+  </section>
+
+  <!-- Scrapyard Sites CTA -->
+  <section class="py-20 bg-gray-100 text-center">
+    <div class="max-w-3xl mx-auto px-6">
+      <p class="text-xl mb-6">If this digital experience matches the service you want on the scale deck, let’s launch yours next.</p>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Book a Demo</a>
+        <a href="https://scrapyardsites.com" target="_blank" rel="noopener" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Visit ScrapyardSites.com</a>
+      </div>
     </div>
   </section>
 </main>

--- a/process.html
+++ b/process.html
@@ -138,6 +138,17 @@
   </div>
 </section>
 
+  <!-- Scrapyard Sites CTA -->
+  <section class="py-20 bg-gray-100 text-center">
+    <div class="max-w-3xl mx-auto px-6">
+      <p class="text-xl mb-6">If this digital experience matches the service you want on the scale deck, let’s launch yours next.</p>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Book a Demo</a>
+        <a href="https://scrapyardsites.com" target="_blank" rel="noopener" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Visit ScrapyardSites.com</a>
+      </div>
+    </div>
+  </section>
+
 </main>
 <!-- ── Footer ──────────────────────────────────────────────── -->
 <footer class="bg-white py-8 text-center text-xs text-gray-400">

--- a/services.html
+++ b/services.html
@@ -109,6 +109,17 @@
   </div>
 </section>
 
+  <!-- Scrapyard Sites CTA -->
+  <section class="py-20 bg-gray-100 text-center">
+    <div class="max-w-3xl mx-auto px-6">
+      <p class="text-xl mb-6">If this digital experience matches the service you want on the scale deck, let’s launch yours next.</p>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Book a Demo</a>
+        <a href="https://scrapyardsites.com" target="_blank" rel="noopener" class="rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Visit ScrapyardSites.com</a>
+      </div>
+    </div>
+  </section>
+
 
 </main>
 


### PR DESCRIPTION
## Summary
- include CTA snippet on materials, contact, FAQ, team, process and services pages

## Testing
- `grep -n "digital experience matches" *.html`


------
https://chatgpt.com/codex/tasks/task_e_6861744edc50832990ace186a97ac865