### PR TITLE
Improve roll-off container section

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -7,6 +7,7 @@
   --color-cards: #F3F4F6;     /* light gray section background */
   --color-headlines: #2B2B2B; /* charcoal headlines and body text */
   --color-links: #D75E02;     /* OSHA‑orange primary accent */
+  --color-accent: #FF6A00;   /* hot-metal orange for callouts */
   --color-success: #5E6367;   /* muted steel for secondary accents */
 }
 
@@ -68,6 +69,9 @@ body {
 .text-brand-charcoal { color: var(--color-headlines) !important; }
 .bg-brand-charcoal { background-color: var(--color-headlines) !important; }
 .border-brand-steel { border-color: var(--color-success) !important; }
+.text-accent { color: var(--color-accent) !important; }
+.bg-accent { background-color: var(--color-accent) !important; }
+.border-accent { border-color: var(--color-accent) !important; }
 
 /* Utility for layering mobile menu above sticky header */
 .z-60 {

--- a/index.html
+++ b/index.html
@@ -17,7 +17,8 @@
             orange: '#D75E02',
             steel:  '#5E6367',
             charcoal: '#2B2B2B'
-          }
+          },
+          accent: '#FF6A00'
         }
       }
     }
@@ -247,12 +248,55 @@
     <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition">Request a Quote</a>
   </div>
 </section>
-<section class="py-20 bg-brand-charcoal text-white text-center">
-  <div class="max-w-4xl mx-auto">
-    <h2 class="text-3xl font-bold mb-6">Need a roll-off tomorrow?</h2>
-    <div class="flex flex-col items-center gap-4">
-      <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Book a Container</a>
-      <a href="tel:555123SCRAP" class="inline-block rounded-md bg-white px-8 py-3 font-semibold text-brand-orange shadow hover:bg-gray-100 transition">Call Dispatch</a>
+<section id="containers" class="bg-accent/10 border-t-4 border-accent py-12 md:py-16">
+  <div class="max-w-7xl mx-auto px-6 md:px-10 grid md:grid-cols-2 gap-10 items-center">
+    <div>
+      <h2 class="text-3xl md:text-4xl font-black tracking-tight">
+        Need a Roll-Off <span class="text-accent">Tomorrow?</span>
+      </h2>
+      <p class="mt-4 text-lg leading-relaxed max-w-prose">
+        Same-day drops, 20-60&nbsp;yd<sup>3</sup> bins, and GPS-tracked
+        drivers who swap your box <em>before</em> your scrap bay backs up.
+      </p>
+      <ul class="mt-6 space-y-3">
+        <li class="flex items-start gap-3">
+          <svg class="w-6 h-6 text-accent" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 6v6l4 2" />
+            <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none"/>
+          </svg>
+          <span><strong>4-hour average response</strong> inside 50 mi radius</span>
+        </li>
+        <li class="flex items-start gap-3">
+          <svg class="w-6 h-6 text-accent" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M3 3h18v2H3zM6 6h12v2H6zM9 9h6v2H9z" />
+          </svg>
+          <span><strong>No rental fees</strong>; freight only—metal value offsets the rest</span>
+        </li>
+        <li class="flex items-start gap-3">
+          <svg class="w-6 h-6 text-accent" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M4 4h16v2H4zM4 8h16v2H4zM4 12h16v2H4zM4 16h16v2H4z" />
+          </svg>
+          <span><strong>E-mailed tonnage report</strong> before the truck leaves your dock</span>
+        </li>
+      </ul>
+      <div class="mt-8 flex flex-col sm:flex-row gap-4">
+        <a href="#quote" class="inline-flex items-center justify-center px-6 py-3 bg-accent text-white font-semibold rounded shadow hover:bg-accent/90">Book a Container</a>
+        <a href="tel:555123SCRAP" class="inline-flex items-center justify-center px-6 py-3 border border-accent text-accent font-semibold rounded hover:bg-accent/10">Call Dispatch</a>
+      </div>
+    </div>
+    <div class="space-y-4">
+      <div class="md:hidden relative rounded-lg overflow-hidden shadow">
+        <img src="https://picsum.photos/seed/rolloff/600/400" alt="Roll-off being winched" class="w-full object-cover">
+        <div class="absolute inset-0 bg-black/60"></div>
+        <span class="absolute bottom-2 right-2 text-xs text-white bg-black/60 px-2 rounded">Tap to enlarge</span>
+      </div>
+      <div class="hidden md:block relative overflow-hidden rounded-lg shadow group">
+        <div class="flex w-[300%] transition-transform duration-700 group-hover:-translate-x-1/3">
+          <img src="https://picsum.photos/seed/bin20/600/400" alt="20 yd bin" class="w-1/3 object-cover">
+          <img src="https://picsum.photos/seed/bin30/600/400" alt="30 yd bin" class="w-1/3 object-cover">
+          <img src="https://picsum.photos/seed/bin60/600/400" alt="60 yd bin" class="w-1/3 object-cover">
+        </div>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- add accent color utility classes for the new orange tone
- revamp "Need a Roll-Off" callout and remove local placeholder images

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861773cbe908329bf48a0cacd3c3217