### PR TITLE
Refine rolloff section visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,11 +248,11 @@
     <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition">Request a Quote</a>
   </div>
 </section>
-<section id="containers" class="bg-accent/10 border-t-4 border-accent py-12 md:py-16">
+<section id="containers" class="bg-brand-orange/10 py-12 md:py-16">
   <div class="max-w-7xl mx-auto px-6 md:px-10 grid md:grid-cols-2 gap-10 items-center">
     <div>
       <h2 class="text-3xl md:text-4xl font-black tracking-tight">
-        Need a Roll-Off <span class="text-accent">Tomorrow?</span>
+        Need a Roll-Off <span class="text-brand-orange">Tomorrow?</span>
       </h2>
       <p class="mt-4 text-lg leading-relaxed max-w-prose">
         Same-day drops, 20-60&nbsp;yd<sup>3</sup> bins, and GPS-tracked
@@ -260,28 +260,21 @@
       </p>
       <ul class="mt-6 space-y-3">
         <li class="flex items-start gap-3">
-          <svg class="w-6 h-6 text-accent" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 6v6l4 2" />
-            <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none"/>
-          </svg>
+          <i class="fa-solid fa-clock text-brand-orange text-xl mt-1"></i>
           <span><strong>4-hour average response</strong> inside 50 mi radius</span>
         </li>
         <li class="flex items-start gap-3">
-          <svg class="w-6 h-6 text-accent" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M3 3h18v2H3zM6 6h12v2H6zM9 9h6v2H9z" />
-          </svg>
+          <i class="fa-solid fa-money-bill-wave text-brand-orange text-xl mt-1"></i>
           <span><strong>No rental fees</strong>; freight only—metal value offsets the rest</span>
         </li>
         <li class="flex items-start gap-3">
-          <svg class="w-6 h-6 text-accent" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M4 4h16v2H4zM4 8h16v2H4zM4 12h16v2H4zM4 16h16v2H4z" />
-          </svg>
+          <i class="fa-solid fa-envelope-open-text text-brand-orange text-xl mt-1"></i>
           <span><strong>E-mailed tonnage report</strong> before the truck leaves your dock</span>
         </li>
       </ul>
       <div class="mt-8 flex flex-col sm:flex-row gap-4">
-        <a href="#quote" class="inline-flex items-center justify-center px-6 py-3 bg-accent text-white font-semibold rounded shadow hover:bg-accent/90">Book a Container</a>
-        <a href="tel:555123SCRAP" class="inline-flex items-center justify-center px-6 py-3 border border-accent text-accent font-semibold rounded hover:bg-accent/10">Call Dispatch</a>
+        <a href="#quote" class="inline-flex items-center justify-center px-6 py-3 rounded-md bg-brand-orange text-white font-semibold shadow-sm hover:opacity-90 transition">Book a Container</a>
+        <a href="tel:555123SCRAP" class="inline-flex items-center justify-center px-6 py-3 rounded-md border border-brand-orange text-brand-orange font-semibold shadow-sm hover:bg-brand-orange/10 transition">Call Dispatch</a>
       </div>
     </div>
     <div class="space-y-4">


### PR DESCRIPTION
## Summary
- adjust rolloff container colors for brand consistency
- use FontAwesome icons for bullet list
- match CTA button styles to rest of the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68617bb351648329993a8d8ff4293df2