### PR TITLE
Adjust final CTA styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,11 +346,11 @@
     <a href="accepted-materials.html" class="inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition">View All</a>
   </div>
 </section>
-<section id="cta-final" class="relative bg-accent text-white py-14 md:py-20" data-aos="fade-up">
+<section id="cta-final" class="relative cta-banner text-white py-14 md:py-20" data-aos="fade-up">
   <div class="max-w-6xl mx-auto px-6 md:px-10 grid md:grid-cols-2 gap-10 items-center">
     <div>
       <h2 class="text-3xl md:text-4xl font-black tracking-tight">
-        Ready to turn scrap into <span class="underline underline-offset-4 decoration-white/40 motion-safe:animate-[pulse_3s_infinite]">cash</span>?
+        Ready to turn scrap into <span>cash</span>?
       </h2>
       <p class="mt-4 text-lg leading-relaxed max-w-prose">
         Pull in today—or lock a roll-off for tomorrow—and leave
@@ -358,16 +358,16 @@
       </p>
       <div class="mt-8 flex flex-col sm:flex-row gap-4">
         <a href="#quote"
-           class="inline-flex items-center justify-center px-6 py-3 bg-white/10 hover:bg-white/20 rounded font-semibold transition motion-safe:hover:underline motion-safe:underline-offset-4">
+           class="inline-flex items-center justify-center px-6 py-3 rounded-md bg-brand-orange text-white font-semibold shadow-sm hover:opacity-90 transition">
            Request a Quote
         </a>
         <a href="tel:555123SCRAP"
-           class="inline-flex items-center justify-center px-6 py-3 bg-white text-accent font-semibold rounded shadow-md hover:bg-white/90 transition motion-safe:hover:scale-105 motion-safe:hover:shadow-lg">
+           class="inline-flex items-center justify-center px-6 py-3 rounded-md border border-brand-orange text-brand-orange font-semibold shadow-sm hover:bg-brand-orange/10 transition">
            Call (555) 123-SCRAP
         </a>
       </div>
       <small class="block mt-4 opacity-80">
-        *Phones answered 7 a – 6 p · Monday – Saturday*
+        Phones answered 7 a – 6 p · Monday – Saturday
       </small>
     </div>
     <div class="relative order-first md:order-none">


### PR DESCRIPTION
## Summary
- animate bottom CTA section with same gradient as stats
- normalize buttons to match main styling
- simplify cash header text
- clean up phone note text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68617ec1fabc8329b8309ab75f026ea0