### PR TITLE
Fix rolloff icon alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,16 +262,16 @@
         drivers who swap your box <em>before</em> your scrap bay backs up.
       </p>
       <ul class="mt-6 space-y-3">
-        <li class="flex items-start gap-3">
-          <i class="fa-solid fa-clock text-brand-orange text-xl mt-1"></i>
+        <li class="flex items-center gap-3">
+          <i class="fa-solid fa-clock text-brand-orange text-xl"></i>
           <span><strong>4-hour average response</strong> inside 50 mi radius</span>
         </li>
-        <li class="flex items-start gap-3">
-          <i class="fa-solid fa-money-bill-wave text-brand-orange text-xl mt-1"></i>
+        <li class="flex items-center gap-3">
+          <i class="fa-solid fa-money-bill-wave text-brand-orange text-xl"></i>
           <span><strong>No rental fees</strong>; freight only—metal value offsets the rest</span>
         </li>
-        <li class="flex items-start gap-3">
-          <i class="fa-solid fa-envelope-open-text text-brand-orange text-xl mt-1"></i>
+        <li class="flex items-center gap-3">
+          <i class="fa-solid fa-envelope-open-text text-brand-orange text-xl"></i>
           <span><strong>E-mailed tonnage report</strong> before the truck leaves your dock</span>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- use `items-center` for rolloff bullet list
- remove margin hack from icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68617ed987b48329a4e012784dddc62b