### PR TITLE
Improve hero CTA hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,8 @@
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
       <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="pricing.html" class="text-sm font-medium text-gray-300">Pricing</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
-    <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
-    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
+    <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm transition-transform transform hover:scale-105 hover:-translate-y-0.5 ml-6">Request a Quote</a>
+    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm transition-transform transform hover:scale-105 hover:-translate-y-0.5 ml-auto mr-3">Request a Quote</a>
     <button id="menuButton" class="md:hidden text-gray-300 focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -92,7 +92,7 @@
       <a href="about.html" class="hover:text-yellow-400">About Us</a>
       <a href="our-team.html" class="hover:text-yellow-400">Our Team</a>
       <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
-      <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
+      <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow transition-transform transform hover:scale-105 hover:-translate-y-0.5">Request a Quote</a>
     </div>
   </header>
 <main class="flex-grow">
@@ -115,7 +115,7 @@
     </p>
     <div class="mt-8 flex flex-col sm:flex-row justify-center gap-4">
       <a href="contact.html"
-         class="rounded-md bg-brand-orange px-8 py-3 text-white font-semibold shadow-lg hover:opacity-90 transition">
+         class="rounded-md bg-brand-orange px-8 py-3 text-white font-semibold shadow-lg transition-transform transform hover:scale-105 hover:-translate-y-0.5">
         Request a Quote
       </a>
       <a href="#services"


### PR DESCRIPTION
## Summary
- avoid repaint-heavy opacity transitions on hero CTA buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861841e70ec8329905b6ce10860eb4b