### PR TITLE
Update about page card styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -174,10 +174,10 @@
   </section>
 
   <!-- What Sets Us Apart -->
-  <section class="py-20">
+  <section class="stats-gradient py-20">
     <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-4 gap-8">
 
-      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
+      <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
 
         <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4"><i class="fa-regular fa-clock"></i></div>
         <div class="text-left md:text-center">
@@ -186,7 +186,7 @@
         </div>
       </div>
 
-      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
+      <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
         <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4"><i class="fa-solid fa-tags"></i></div>
         <div class="text-left md:text-center">
           <h3 class="font-semibold text-lg mb-2">Certified Accuracy</h3>
@@ -194,7 +194,7 @@
         </div>
       </div>
 
-      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
+      <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
 
         <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4"><i class="fa-solid fa-recycle"></i></div>
         <div class="text-left md:text-center">
@@ -203,7 +203,7 @@
         </div>
       </div>
 
-      <div class="rounded-xl bg-orange-50 border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
+      <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">
 
         <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4"><i class="fa-solid fa-handshake"></i></div>
         <div class="text-left md:text-center">


### PR DESCRIPTION
## Summary
- update the About Us card section with animated gradient background
- use white cards instead of orange

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68618704f1448329981e634154da9073