### PR TITLE
Add opacity fade to hero CTAs

### DIFF
--- a/about.html
+++ b/about.html
@@ -104,7 +104,7 @@
         Built on Metal, Powered by Integrity
       </h1>
       <p class="mt-4 text-xl text-white">Two decades, one promise—fair pay, full respect, zero shortcuts.</p>
-      <a href="#people" class="mt-8 inline-block rounded-md border border-white px-6 py-3 text-white hover:bg-white/10 transition">Meet the Team ↓</a>
+      <a href="#people" class="mt-8 inline-block rounded-md border border-white px-6 py-3 text-white hover:bg-white/10 transition hover:opacity-90">Meet the Team ↓</a>
     </div>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -115,11 +115,11 @@
     </p>
     <div class="mt-8 flex flex-col sm:flex-row justify-center gap-4">
       <a href="contact.html"
-         class="rounded-md bg-brand-orange px-8 py-3 text-white font-semibold shadow-lg transition-transform transform hover:scale-105 hover:-translate-y-0.5">
+         class="rounded-md bg-brand-orange px-8 py-3 text-white font-semibold shadow-lg transition transform hover:scale-105 hover:-translate-y-0.5 hover:opacity-90">
         Request a Quote
       </a>
       <a href="#services"
-         class="inline-block rounded-md border border-white px-6 py-3 text-white hover:bg-white/10 transition">
+         class="inline-block rounded-md border border-white px-6 py-3 text-white hover:bg-white/10 transition hover:opacity-90">
         Our Services ↓
       </a>
     </div>
@@ -358,11 +358,11 @@
       </p>
         <div class="mt-8 flex flex-col sm:flex-row gap-4">
         <a href="#quote"
-           class="inline-flex items-center justify-center px-6 py-3 rounded-md border border-white text-white font-semibold hover:bg-white/10 transition">
+           class="inline-flex items-center justify-center px-6 py-3 rounded-md border border-white text-white font-semibold hover:bg-white/10 transition hover:opacity-90">
            Request a Quote
         </a>
         <a href="tel:555123SCRAP"
-           class="inline-flex items-center justify-center px-6 py-3 rounded-md border border-white text-white font-semibold hover:bg-white/10 transition">
+           class="inline-flex items-center justify-center px-6 py-3 rounded-md border border-white text-white font-semibold hover:bg-white/10 transition hover:opacity-90">
            Call (555) 123-SCRAP
         </a>
       </div>

--- a/services.html
+++ b/services.html
@@ -103,11 +103,11 @@
   <h1 class="text-4xl md:text-5xl font-extrabold z-10">Five Ways We Turn Scrap Into Cash.</h1>
   <p class="mt-4 text-lg z-10">Choose the option that fits your haul, schedule, and job-site.</p>
   <div class="mt-8 flex flex-col sm:flex-row gap-4 z-10">
-    <a href="#buying" class="rounded-md bg-white/10 px-6 py-3 font-semibold hover:bg-white/20">Walk-In Buying</a>
-    <a href="#containers" class="rounded-md bg-white/10 px-6 py-3 font-semibold hover:bg-white/20">Roll-Offs</a>
-    <a href="#demo" class="rounded-md bg-white/10 px-6 py-3 font-semibold hover:bg-white/20">Demolition</a>
-    <a href="#converters" class="rounded-md bg-white/10 px-6 py-3 font-semibold hover:bg-white/20">Converters</a>
-    <a href="#escrap" class="rounded-md bg-white/10 px-6 py-3 font-semibold hover:bg-white/20">E-Scrap</a>
+    <a href="#buying" class="rounded-md bg-white/10 px-6 py-3 font-semibold transition hover:opacity-90 hover:bg-white/20">Walk-In Buying</a>
+    <a href="#containers" class="rounded-md bg-white/10 px-6 py-3 font-semibold transition hover:opacity-90 hover:bg-white/20">Roll-Offs</a>
+    <a href="#demo" class="rounded-md bg-white/10 px-6 py-3 font-semibold transition hover:opacity-90 hover:bg-white/20">Demolition</a>
+    <a href="#converters" class="rounded-md bg-white/10 px-6 py-3 font-semibold transition hover:opacity-90 hover:bg-white/20">Converters</a>
+    <a href="#escrap" class="rounded-md bg-white/10 px-6 py-3 font-semibold transition hover:opacity-90 hover:bg-white/20">E-Scrap</a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- add opacity fade animation for hero CTAs on the home page
- fade hero CTA button on About page
- update hero CTA buttons on Services page

## Testing
- `ls package.json`

------
https://chatgpt.com/codex/tasks/task_e_6861898e32908329a683f3b5137ff5fb