### PR TITLE
Fix about card background

### DIFF
--- a/about.html
+++ b/about.html
@@ -174,7 +174,7 @@
   </section>
 
   <!-- What Sets Us Apart -->
-  <section class="stats-gradient py-20">
+  <section class="py-20 bg-brand-orange">
     <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-4 gap-8">
 
       <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm transition transform hover:-translate-y-1 p-8 flex items-center md:flex-col md:text-center">


### PR DESCRIPTION
## Summary
- remove animated gradient from the "What Sets Us Apart" section on the About page so it uses a solid orange background

## Testing
- `htmlhint about.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618c4a2fb48329940069dbf440e987