### PR TITLE
Fix services page font link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Power-Launch-Demo
+# Power-Launch Demo
+
+This repository contains a static demo website for a fictional scrapyard called **Demo Yard**. Open `index.html` in a browser to explore the landing page and navigate to other pages like Services or Pricing.
+
+All styles and behavior are implemented with Tailwind CSS and small JavaScript helpers in `script.js`.

--- a/about.html
+++ b/about.html
@@ -24,7 +24,7 @@
   };
 </script>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
-<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap' rel='stylesheet'>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="assets/styles.css">
 <meta name="description" content="Learn about Demo Yard's commitment to fair pricing, quick turnarounds, and exceptional service.">

--- a/accepted-materials.html
+++ b/accepted-materials.html
@@ -24,7 +24,7 @@
   };
 </script>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
-<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap' rel='stylesheet'>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="assets/styles.css">
 <meta name="description" content="See what scrap metals Demo Yard accepts for recycling.">

--- a/contact.html
+++ b/contact.html
@@ -24,7 +24,7 @@
   };
 </script>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
-<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap' rel='stylesheet'>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="assets/styles.css">
 <meta name="description" content="Get in touch with Demo Yard for scrap metal recycling services, quotes, or general inquiries.">

--- a/faq.html
+++ b/faq.html
@@ -24,7 +24,7 @@
   };
 </script>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
-<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap' rel='stylesheet'>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="assets/styles.css">
 <meta name="description" content="Find answers to common questions about Demo Yard's scrap metal services and policies.">

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   };
 </script>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
-<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap' rel='stylesheet'>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="assets/styles.css">
 <meta name="description" content="Demo Yard offers top dollar for scrap metal with fast, reliable service in the metro area.">

--- a/our-team.html
+++ b/our-team.html
@@ -24,7 +24,7 @@
   };
 </script>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
-<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap' rel='stylesheet'>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="assets/styles.css">
 <meta name="description" content="Meet the dedicated Demo Yard team behind our trusted service.">

--- a/pricing.html
+++ b/pricing.html
@@ -24,7 +24,7 @@
   };
 </script>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="assets/styles.css">
 <meta name="description" content="Explore Demo Yard's transparent pricing for ferrous and non-ferrous metal recycling.">

--- a/process.html
+++ b/process.html
@@ -24,7 +24,7 @@
   };
 </script>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
-<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap' rel='stylesheet'>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="assets/styles.css">
 <meta name="description" content="Understand Demo Yard's scrap metal recycling process from drop-off to payment.">

--- a/services.html
+++ b/services.html
@@ -25,7 +25,7 @@
   };
 </script>
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
-<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&amp;display=swap' rel='stylesheet'>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css">
 <link rel="stylesheet" href="assets/styles.css">


### PR DESCRIPTION
## Summary
- update README with a short project description
- escape '&' in Google Fonts link across all HTML files

## Testing
- `tidy -qe services.html`
- `tidy -qe about.html`
- `tidy -qe index.html`


------
https://chatgpt.com/codex/tasks/task_e_686199c57c3883298268091d21ed2c71