### PR TITLE
Fix JS counters + team carousel

### DIFF
--- a/script.js
+++ b/script.js
@@ -70,7 +70,7 @@ function initMenu() {
           obs.unobserve(entry.target);
         }
       });
-    }, { threshold: 0.6 });
+    }, { threshold: 0.4 });
 
     counters.forEach(el => observer.observe(el));
   } else if (prefersReduced) {
@@ -162,6 +162,8 @@ function initMaterialSearch() {
         sec.classList.add('hidden');
       }
     });
+  });
+}
 
 function initTimeline() {
   const steps = document.querySelectorAll('.timeline-step');
@@ -184,6 +186,35 @@ function initTimeline() {
   });
 }
 
+function initTeamCarousel() {
+  const container = document.getElementById('teamCarousel');
+  if (!container) return;
+  const slides = container.querySelectorAll('.carousel-slide');
+  const dots = container.querySelectorAll('.carousel-dot');
+  let index = 0;
+  const show = (i) => {
+    slides.forEach((s, idx) => {
+      if (idx === i) {
+        s.classList.remove('hidden');
+      } else {
+        s.classList.add('hidden');
+      }
+    });
+    dots.forEach((d, idx) => {
+      d.classList.toggle('bg-brand-orange', idx === i);
+    });
+  };
+  show(index);
+  setInterval(() => {
+    index = (index + 1) % slides.length;
+    show(index);
+  }, 4000);
+  dots.forEach((d, idx) => d.addEventListener('click', () => {
+    index = idx;
+    show(index);
+  }));
+}
+
 function initPage() {
   initMenu();
   initFlyOver();
@@ -192,6 +223,8 @@ function initPage() {
   initMaterialSearch();
 
   initTimeline();
+
+  initTeamCarousel();
 
 }
 


### PR DESCRIPTION
## Summary
- update stats counters IntersectionObserver threshold
- close material search listener correctly
- add simple team photo carousel helper
- call carousel init in page init

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68619d1249a88329b3ec8d04393c4cb6