### PR TITLE
Fix syntax error due to missing braces

### DIFF
--- a/script.js
+++ b/script.js
@@ -163,6 +163,10 @@ function initMaterialSearch() {
       }
     });
 
+    // Close the input event handler and the initMaterialSearch function
+  });
+}
+
 function initTimeline() {
   const steps = document.querySelectorAll('.timeline-step');
   const line = document.querySelector('.timeline-line');


### PR DESCRIPTION
## Summary
- close the `initMaterialSearch` event handler properly

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6861a012638083298aa4b3b76bcd2ebe