### PR TITLE
Remove search bar and tweak copper accordion

### DIFF
--- a/accepted-materials.html
+++ b/accepted-materials.html
@@ -132,12 +132,6 @@
     </div>
   </section>
 
-  <!-- Search Bar -->
-  <section class="py-8 bg-white">
-    <div class="max-w-3xl mx-auto px-6">
-      <input id="materialSearch" type="search" aria-label="Search materials" placeholder="Search a material" class="w-full border border-brand-steel/30 rounded-md p-3" />
-    </div>
-  </section>
 
   <!-- Details Accordion -->
   <section class="space-y-8 max-w-6xl mx-auto px-6" id="details">
@@ -145,8 +139,8 @@
       <details>
         <summary class="flex items-center justify-between p-4 bg-white border rounded-lg cursor-pointer">
           <span class="flex items-center gap-3">
-            <i class="fa-solid fa-pipe text-2xl"></i>
-            <h2 class="text-lg font-bold">#1 Copper &amp; Brass</h2>
+            <i class="fa-solid fa-coins text-2xl"></i>
+            <h2 class="text-lg font-bold">Copper &amp; Brass</h2>
           </span>
           <svg class="arrow w-5 h-5 ml-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
         </summary>

--- a/script.js
+++ b/script.js
@@ -148,27 +148,6 @@ function initYardMap() {
 }
 
 
-function initMaterialSearch() {
-  const input = document.getElementById('materialSearch');
-  if (!input) return;
-  input.addEventListener('input', () => {
-    const term = input.value.trim().toLowerCase();
-    const sections = document.querySelectorAll('.material-details');
-    sections.forEach(sec => {
-      const text = sec.textContent.toLowerCase();
-      if (text.includes(term)) {
-        sec.classList.remove('hidden');
-      } else {
-        sec.classList.add('hidden');
-      }
-    });
-  });
-}
-
-
-    // Close the input event handler and the initMaterialSearch function
-  });
-}
 
 
 function initTimeline() {
@@ -277,7 +256,6 @@ function initPage() {
   initFlyOver();
   initYardMap();
 
-  initMaterialSearch();
 
   initTimeline();
 


### PR DESCRIPTION
## Summary
- drop material search input from the materials page
- switch the copper & brass title to use the `fa-coins` icon and remove `#1`
- delete search helper from the main script

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6861a451142483299c2d7c901d5c5bbc