### PR TITLE
Adjust Process page layout

### DIFF
--- a/process.html
+++ b/process.html
@@ -132,7 +132,6 @@
   <section class="py-20 bg-white">
     <div class="timeline-container max-w-[1024px] mx-auto px-6">
       <ul class="timeline flex flex-col md:flex-row justify-between gap-8 md:gap-14 relative">
-        <div class="timeline-line hidden md:block absolute top-12 left-0 right-0 h-px bg-brand-steel"></div>
         <li class="timeline-step relative flex flex-col items-start md:items-center text-left md:text-center">
           <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">
             <img src="assets/clipboard-document-list.svg" alt="Check Material" class="w-8 md:w-10">
@@ -160,8 +159,12 @@
       </ul>
     </div>
   </section>
+  <aside class="process-tip mx-auto max-w-3xl px-6 mt-8 justify-center text-center">
+    <svg class="w-5 h-5 text-brand-orange mr-2" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L9.586 11H3a1 1 0 110-2h6.586L7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
+    <strong>Quick reminder:</strong>&nbsp;Drain fuel, oil and refrigerants—wet loads can’t be accepted.
+  </aside>
 
-  <section class="bg-[#004840] text-white">
+  <section class="bg-[#006a4e] text-white">
     <div class="max-w-6xl mx-auto flex flex-col md:flex-row text-center divide-y md:divide-y-0 md:divide-x divide-white/20">
       <div class="flex-1 py-4">10&nbsp;min – Avg. yard time</div>
       <div class="flex-1 py-4">5&nbsp;min – Clean loads</div>
@@ -169,10 +172,6 @@
     </div>
   </section>
 
-  <aside class="process-tip mx-auto max-w-3xl px-6 mt-8">
-    <svg class="w-5 h-5 text-brand-orange mr-2" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L9.586 11H3a1 1 0 110-2h6.586L7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
-    <strong>Quick reminder:</strong>&nbsp;Drain fuel, oil and refrigerants—wet loads can’t be accepted.
-  </aside>
 
 
 


### PR DESCRIPTION
## Summary
- remove connecting line from Process timeline
- recolor Process page banner
- show quick reminder directly below the timeline and center it

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861a4e547548329bffc795d4f010845