### PR TITLE
Apply flip card style to process steps

### DIFF
--- a/process.html
+++ b/process.html
@@ -132,29 +132,47 @@
   <section class="py-20 bg-white">
     <div class="timeline-container max-w-[1024px] mx-auto px-6">
       <ul class="timeline flex flex-col md:flex-row justify-between gap-8 md:gap-14 relative">
-        <li class="timeline-step relative flex flex-col items-start md:items-center text-left md:text-center">
-          <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">
-            <img src="assets/clipboard-document-list.svg" alt="Check Material" class="w-8 md:w-10">
+        <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center">
+          <div class="flip-card-inner h-60">
+            <div class="flip-front flex flex-col items-center justify-center p-4">
+              <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">
+                <img src="assets/clipboard-document-list.svg" alt="Check Material" class="w-8 md:w-10">
+              </div>
+              <h3 class="mt-4 text-base md:text-lg font-semibold">Check&nbsp;Your&nbsp;Material</h3>
+              <p class="mt-2 text-sm md:text-[15px] max-w-[220px] mx-auto">Browse Accepted Materials or text us a photo.</p>
+            </div>
+            <div class="flip-back bg-white rounded-lg flex items-center justify-center p-4 text-sm text-brand-charcoal">
+              Haz‑mat? Liquids? Give us a call first.
+            </div>
           </div>
-          <h3 class="mt-4 text-base md:text-lg font-semibold">Check&nbsp;Your&nbsp;Material</h3>
-          <p class="mt-2 text-sm md:text-[15px] max-w-[220px]">Browse Accepted Materials or text us a photo.</p>
-          <div class="timeline-tip hidden absolute md:-top-14 md:left-1/2 md:-translate-x-1/2 bg-white border border-brand-steel text-xs text-brand-charcoal rounded-md shadow px-2 py-1">Haz‑mat? Liquids? Give us a call first.</div>
         </li>
-        <li class="timeline-step relative flex flex-col items-start md:items-center text-left md:text-center">
-          <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">
-            <img src="assets/truck.svg" alt="Drive On" class="w-8 md:w-10">
+        <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center">
+          <div class="flip-card-inner h-60">
+            <div class="flip-front flex flex-col items-center justify-center p-4">
+              <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">
+                <img src="assets/truck.svg" alt="Drive On" class="w-8 md:w-10">
+              </div>
+              <h3 class="mt-4 text-base md:text-lg font-semibold">Drive&nbsp;On&nbsp;&amp;&nbsp;Unload</h3>
+              <p class="mt-2 text-sm md:text-[15px] max-w-[220px] mx-auto">Roll onto the calibrated scale, get a yard pass; crew grades &amp; unloads.</p>
+            </div>
+            <div class="flip-back bg-white rounded-lg flex items-center justify-center p-4 text-sm text-brand-charcoal">
+              Leave batteries &amp; copper up front for quickest check‑out.
+            </div>
           </div>
-          <h3 class="mt-4 text-base md:text-lg font-semibold">Drive&nbsp;On&nbsp;&amp;&nbsp;Unload</h3>
-          <p class="mt-2 text-sm md:text-[15px] max-w-[220px]">Roll onto the calibrated scale, get a yard pass; crew grades &amp; unloads.</p>
-          <div class="timeline-tip hidden absolute md:-top-14 md:left-1/2 md:-translate-x-1/2 bg-white border border-brand-steel text-xs text-brand-charcoal rounded-md shadow px-2 py-1">Leave batteries &amp; copper up front for quickest check‑out.</div>
         </li>
-        <li class="timeline-step relative flex flex-col items-start md:items-center text-left md:text-center">
-          <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">
-            <img src="assets/banknotes.svg" alt="Get Paid" class="w-8 md:w-10">
+        <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center">
+          <div class="flip-card-inner h-60">
+            <div class="flip-front flex flex-col items-center justify-center p-4">
+              <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">
+                <img src="assets/banknotes.svg" alt="Get Paid" class="w-8 md:w-10">
+              </div>
+              <h3 class="mt-4 text-base md:text-lg font-semibold">Get&nbsp;Paid—Instantly</h3>
+              <p class="mt-2 text-sm md:text-[15px] max-w-[220px] mx-auto">Weight ticket prints; choose Cash, ACH, or Check.</p>
+            </div>
+            <div class="flip-back bg-white rounded-lg flex items-center justify-center p-4 text-sm text-brand-charcoal">
+              Opt‑in for weekly ACH if you’re an industrial account.
+            </div>
           </div>
-          <h3 class="mt-4 text-base md:text-lg font-semibold">Get&nbsp;Paid—Instantly</h3>
-          <p class="mt-2 text-sm md:text-[15px] max-w-[220px]">Weight ticket prints; choose Cash, ACH, or Check.</p>
-          <div class="timeline-tip hidden absolute md:-top-14 md:left-1/2 md:-translate-x-1/2 bg-white border border-brand-steel text-xs text-brand-charcoal rounded-md shadow px-2 py-1">Opt‑in for weekly ACH if you’re an industrial account.</div>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- convert each process step into a flip-card
- show tip text on card back instead of hover tooltip

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861a8d18d84832987e38dfe8cd0ea95