### PR TITLE
Fix process timeline card styles

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -258,6 +258,7 @@ header nav a:hover::after,
 }
 .material-details details[open] summary .arrow {
   transform: rotate(90deg);
+}
 /* Process page utilities */
 .process-tip {
   background-color: #FFFBE6;


### PR DESCRIPTION
## Summary
- close missing CSS rule in styles.css

## Testing
- `tidy -q process.html`

------
https://chatgpt.com/codex/tasks/task_e_6861aace94c88329b61bbf2d63a4d113