### PR TITLE
Fix details header alignment on Materials page

### DIFF
--- a/accepted-materials.html
+++ b/accepted-materials.html
@@ -134,8 +134,8 @@
 
 
   <!-- Details Accordion -->
-  <section class="space-y-8 max-w-6xl mx-auto px-6" id="details">
-    <h2 class="text-3xl font-bold mb-8">Details</h2>
+  <section id="details" class="space-y-8 max-w-6xl mx-auto px-6 pt-20">
+    <h2 class="text-3xl font-bold mb-8 text-center">Details</h2>
     <section id="copper" class="material-details">
       <details>
         <summary class="flex items-center justify-between p-4 bg-white border rounded-lg cursor-pointer">


### PR DESCRIPTION
## Summary
- center the Details header text
- add top padding to the Details section so it matches other sections

## Testing
- `git diff`

------
https://chatgpt.com/codex/tasks/task_e_6861ab0c8c848329a93e53bf430b603d