### PR TITLE
Fix team card display on Our Team page

### DIFF
--- a/our-team.html
+++ b/our-team.html
@@ -96,7 +96,7 @@
   <section id="team" class="py-20">
     <div class="max-w-6xl mx-auto px-6 grid gap-8 team-grid sm:grid-cols-2 lg:grid-cols-3">
       <div id="alex" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner">
+        <div class="flip-card-inner h-80">
           <div class="flip-front flex flex-col items-center text-center">
             <img src="assets/hero.jpg" alt="Alex Martinez" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
             <h3 class="font-semibold text-lg">Alex Martinez</h3>
@@ -109,7 +109,7 @@
         </div>
       </div>
       <div id="jamie" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner">
+        <div class="flip-card-inner h-80">
           <div class="flip-front flex flex-col items-center text-center">
             <img src="assets/hero.jpg" alt="Jamie Patel" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
             <h3 class="font-semibold text-lg">Jamie Patel</h3>
@@ -122,7 +122,7 @@
         </div>
       </div>
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner">
+        <div class="flip-card-inner h-80">
           <div class="flip-front flex flex-col items-center text-center">
             <img src="assets/hero.jpg" alt="Riley Thompson" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
             <h3 class="font-semibold text-lg">Riley Thompson</h3>
@@ -135,7 +135,7 @@
         </div>
       </div>
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner">
+        <div class="flip-card-inner h-80">
           <div class="flip-front flex flex-col items-center text-center">
             <img src="assets/hero.jpg" alt="Mike 'Sparky' Nguyen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
             <h3 class="font-semibold text-lg">Mike “Sparky” Nguyen</h3>
@@ -148,7 +148,7 @@
         </div>
       </div>
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner">
+        <div class="flip-card-inner h-80">
           <div class="flip-front flex flex-col items-center text-center">
             <img src="assets/hero.jpg" alt="Victoria Chen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
             <h3 class="font-semibold text-lg">Victoria Chen</h3>


### PR DESCRIPTION
## Summary
- ensure flip cards have explicit height to display correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861ab3cb9d08329990ebb6b4594c375