### PR TITLE
Remove hero animation from Services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -99,7 +99,7 @@
 <main class="flex-grow">
 
 <!-- Hero -->
-<section id="top" class="scroll-mt-16 relative isolate flex items-center justify-center text-center text-white min-h-[60vh] md:min-h-screen" data-aos="fade-up">
+<section id="top" class="scroll-mt-16 relative isolate flex items-center justify-center text-center text-white min-h-[60vh] md:min-h-screen">
   <div class="absolute inset-0 -z-10">
     <img src="assets/hero.jpg" alt="" class="w-full h-full object-cover blur-[15px]">
     <div class="absolute inset-0 bg-brand-teal/75"></div>


### PR DESCRIPTION
## Summary
- removed the `data-aos` fade effect from the Services hero section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861aa9ff7588329ba7c745c9f8a93f8