### PR TITLE
Fix bullet markers on Process page

### DIFF
--- a/process.html
+++ b/process.html
@@ -131,7 +131,7 @@
 
   <section class="py-20 bg-white">
     <div class="timeline-container max-w-[1024px] mx-auto px-6">
-      <ul class="timeline flex flex-col md:flex-row justify-between gap-8 md:gap-14 relative">
+      <ul class="timeline list-none flex flex-col md:flex-row justify-between gap-8 md:gap-14 relative">
         <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center">
           <div class="flip-card-inner h-60">
             <div class="flip-front flex flex-col items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- removed bullet markers from the timeline list so cards show properly

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6861ac547c388329a6c37f75d2682d65