### PR TITLE
Fix timeline card width

### DIFF
--- a/process.html
+++ b/process.html
@@ -132,7 +132,7 @@
   <section class="py-20 bg-white">
     <div class="timeline-container max-w-[1024px] mx-auto px-6">
       <ul class="timeline list-none flex flex-col md:flex-row justify-between gap-8 md:gap-14 relative">
-        <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center">
+        <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center w-full md:w-1/3">
           <div class="flip-card-inner h-60">
             <div class="flip-front flex flex-col items-center justify-center p-4">
               <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">
@@ -146,7 +146,7 @@
             </div>
           </div>
         </li>
-        <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center">
+        <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center w-full md:w-1/3">
           <div class="flip-card-inner h-60">
             <div class="flip-front flex flex-col items-center justify-center p-4">
               <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">
@@ -160,7 +160,7 @@
             </div>
           </div>
         </li>
-        <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center">
+        <li class="timeline-step flip-card bg-white rounded-lg shadow border border-brand-steel/10 transition-transform hover:-translate-y-1 text-center w-full md:w-1/3">
           <div class="flip-card-inner h-60">
             <div class="flip-front flex flex-col items-center justify-center p-4">
               <div class="icon w-16 h-16 md:w-24 md:h-24 flex items-center justify-center rounded-full border-2 border-brand-steel text-brand-steel transition-transform">


### PR DESCRIPTION
## Summary
- adjust timeline step classes to prevent collapsed layout on Process page

## Testing
- `npm test` *(fails: no package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861aee273c48329a89c5028e698bd93