### PR TITLE
Remove hero overlay from services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -101,8 +101,7 @@
 <!-- Hero -->
 <section id="top" class="scroll-mt-16 relative isolate flex items-center justify-center text-center text-white min-h-[60vh] md:min-h-screen">
   <div class="absolute inset-0 -z-10">
-    <img src="assets/hero.jpg" alt="" class="w-full h-full object-cover blur-[15px]">
-    <div class="absolute inset-0 bg-brand-teal/75"></div>
+    <img src="assets/hero.jpg" alt="" class="w-full h-full object-cover">
   </div>
   <div class="flex flex-col items-center justify-center w-full h-full px-6">
     <h1 class="text-[7vw] md:text-6xl font-extrabold">Five Ways We Turn Scrap Into Cash.</h1>


### PR DESCRIPTION
## Summary
- remove the green overlay and blur from the Services page hero

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6861b086db408329bbbed25bf9200e2d