### PR TITLE
Adjust team page layout

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -285,5 +285,5 @@ header nav a:hover::after,
 .team-card.flipped .flip-card-inner { transform: rotateY(180deg); }
 
 
-/* Ensure team card images are circular */
-.team-card img { border-radius: 50%; }
+/* Display team photos with rounded corners */
+.team-card img { border-radius: 0.5rem; }

--- a/our-team.html
+++ b/our-team.html
@@ -92,9 +92,9 @@
   <section id="team" class="py-20">
     <div class="max-w-6xl mx-auto px-6 grid gap-8 team-grid sm:grid-cols-2 lg:grid-cols-2">
       <div id="alex" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner h-80">
+        <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Alex Martinez" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
+            <img src="assets/hero.jpg" alt="Alex Martinez" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Alex Martinez</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Operations Manager</p>
             <p class="text-sm text-brand-steel">15‑yr vet, OSHA‑30, keeps the yard humming.</p>
@@ -105,9 +105,9 @@
         </div>
       </div>
       <div id="jamie" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner h-80">
+        <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Jamie Patel" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
+            <img src="assets/hero.jpg" alt="Jamie Patel" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Jamie Patel</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Logistics Coordinator</p>
             <p class="text-sm text-brand-steel">GPS-tracked roll-off ninja.</p>
@@ -118,9 +118,9 @@
         </div>
       </div>
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner h-80">
+        <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Riley Thompson" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
+            <img src="assets/hero.jpg" alt="Riley Thompson" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Riley Thompson</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Customer Success Lead</p>
             <p class="text-sm text-brand-steel">Friendly face at the pay-window.</p>
@@ -131,9 +131,9 @@
         </div>
       </div>
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner h-80">
+        <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Mike 'Sparky' Nguyen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
+            <img src="assets/hero.jpg" alt="Mike 'Sparky' Nguyen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Mike “Sparky” Nguyen</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Demolition Foreman</p>
             <p class="text-sm text-brand-steel">Licensed torch cutter. Problem solver.</p>
@@ -144,9 +144,9 @@
         </div>
       </div>
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner h-80">
+        <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Victoria Chen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-full mb-3">
+            <img src="assets/hero.jpg" alt="Victoria Chen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Victoria Chen</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Environmental &amp; Compliance</p>
             <p class="text-sm text-brand-steel">Paperwork pro and training lead.</p>
@@ -210,13 +210,10 @@
         <span class="bg-white text-brand-charcoal px-3 py-1 rounded-full text-sm font-semibold">Paid OSHA certs</span>
         <span class="bg-white text-brand-charcoal px-3 py-1 rounded-full text-sm font-semibold">Monthly BBQ</span>
       </div>
-      <a href="careers.html" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">View Open Roles</a>
+      <a href="careers.html" class="rounded-md bg-white text-brand-orange px-8 py-3 font-semibold shadow hover:bg-white/90 transition">View Open Roles</a>
     </div>
   </section>
 </main>
-<div id="quoteBar" class="fixed bottom-0 left-0 right-0 bg-brand-orange text-white py-3 px-6 flex justify-center items-center shadow-md transition-transform translate-y-full">
-  <a href="contact.html" class="flex items-center gap-2 font-semibold"><i class="fa-solid fa-phone"></i> Request a Quote</a>
-</div>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>


### PR DESCRIPTION
## Summary
- make team cards square and display member photos with rounded corners
- remove sticky quote request bar
- style open roles button with white background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861b4165d08832993f24521981977ab