### PR TITLE
Update Process page banners

### DIFF
--- a/process.html
+++ b/process.html
@@ -129,6 +129,14 @@
     </div>
   </section>
 
+  <section class="bg-[#006a4e] text-white">
+    <div class="max-w-6xl mx-auto flex flex-col md:flex-row text-center divide-y md:divide-y-0 md:divide-x divide-white/20">
+      <div class="flex-1 py-4">10&nbsp;min – Avg. yard time</div>
+      <div class="flex-1 py-4">5&nbsp;min – Clean loads</div>
+      <div class="flex-1 py-4">0 – Appointments needed</div>
+    </div>
+  </section>
+
   <section class="py-20 bg-gray-100">
     <div class="timeline-container max-w-[1024px] mx-auto px-6">
       <h2 class="text-3xl font-bold text-center mb-8">How It Works</h2>
@@ -189,18 +197,11 @@
       </ul>
     </div>
   </section>
-  <aside class="process-tip mx-auto max-w-3xl px-6 mt-8 justify-center text-center">
+  <aside class="process-tip mx-auto max-w-3xl px-6 mt-8">
     <svg class="w-5 h-5 text-brand-orange mr-2" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L9.586 11H3a1 1 0 110-2h6.586L7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
     <strong>Quick reminder:</strong>&nbsp;Drain fuel, oil and refrigerants—wet loads can’t be accepted.
   </aside>
 
-  <section class="bg-[#006a4e] text-white">
-    <div class="max-w-6xl mx-auto flex flex-col md:flex-row text-center divide-y md:divide-y-0 md:divide-x divide-white/20">
-      <div class="flex-1 py-4">10&nbsp;min – Avg. yard time</div>
-      <div class="flex-1 py-4">5&nbsp;min – Clean loads</div>
-      <div class="flex-1 py-4">0 – Appointments needed</div>
-    </div>
-  </section>
 
 
 


### PR DESCRIPTION
## Summary
- reposition the yard stats banner to sit above the How It Works section
- improve layout of the Quick Reminder banner

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861bac6e41083299d398099acffc9b4