### PR TITLE
Update process page styling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -88,6 +88,13 @@ header.sticky {
   flex-shrink: 0; /* prevent collapsing in flex layouts */
 }
 
+/* Provide fallback sticky behavior in case Tailwind classes fail */
+header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
 /* Nav bar underline animation */
 header nav a,
 #mobileMenu a:not(.bg-yellow-500) {
@@ -287,3 +294,12 @@ header nav a:hover::after,
 
 /* Display team photos with rounded corners */
 .team-card img { border-radius: 0.5rem; }
+
+/* Review carousel tweaks */
+.review-carousel {
+  overflow: hidden;
+}
+.review-carousel .slick-slide {
+  border: none;
+  outline: none;
+}

--- a/process.html
+++ b/process.html
@@ -129,7 +129,7 @@
     </div>
   </section>
 
-  <section class="bg-[#006a4e] text-white">
+  <section class="bg-brand-orange text-white">
     <div class="max-w-6xl mx-auto flex flex-col md:flex-row text-center divide-y md:divide-y-0 md:divide-x divide-white/20">
       <div class="flex-1 py-4">10&nbsp;min – Avg. yard time</div>
       <div class="flex-1 py-4">5&nbsp;min – Clean loads</div>
@@ -137,7 +137,7 @@
     </div>
   </section>
 
-  <section class="py-20 bg-gray-100">
+  <section class="pt-20 pb-0 bg-gray-100">
     <div class="timeline-container max-w-[1024px] mx-auto px-6">
       <h2 class="text-3xl font-bold text-center mb-8">How It Works</h2>
       <ul class="timeline list-none flex flex-col md:flex-row justify-between gap-8 md:gap-14 relative">
@@ -197,7 +197,7 @@
       </ul>
     </div>
   </section>
-  <aside class="process-tip mx-auto max-w-3xl px-6 mt-8">
+  <aside class="process-tip w-full px-6">
     <svg class="w-5 h-5 text-brand-orange mr-2" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L9.586 11H3a1 1 0 110-2h6.586L7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
     <strong>Quick reminder:</strong>&nbsp;Drain fuel, oil and refrigerants—wet loads can’t be accepted.
   </aside>
@@ -206,7 +206,7 @@
 
 
 
-<section class="py-20 bg-gray-100">
+<section class="py-20 bg-white">
   <div class="max-w-3xl mx-auto px-6">
     <h2 class="text-3xl font-bold text-center mb-8">Quick FAQ</h2>
     <div class="space-y-4">
@@ -259,7 +259,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
 <script>
   if (window.jQuery && document.querySelector('.review-carousel')) {
-    $('.review-carousel').slick({ dots: true, arrows: false });
+    $('.review-carousel').slick({ dots: true, arrows: false, autoplay: true, autoplaySpeed: 4000 });
   }
 </script>
 <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- ensure header remains sticky across pages
- update review carousel styling and auto-play
- switch yard stats banner to brand orange
- remove spacing before "Quick reminder" alert and make it full width
- set Quick FAQ background to white

## Testing
- `tidy -errors -q process.html`

------
https://chatgpt.com/codex/tasks/task_e_6861bdd8d2b88329837cd1283ca86f45