### PR TITLE
Shrink team member cards

### DIFF
--- a/our-team.html
+++ b/our-team.html
@@ -90,11 +90,11 @@
     </div>
   </section>
   <section id="team" class="py-20">
-    <div class="max-w-6xl mx-auto px-6 grid gap-8 team-grid sm:grid-cols-2 lg:grid-cols-2">
+    <div class="max-w-6xl mx-auto px-6 grid gap-8 team-grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
       <div id="alex" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Alex Martinez" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Alex Martinez" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Alex Martinez</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Operations Manager</p>
             <p class="text-sm text-brand-steel">15‑yr vet, OSHA‑30, keeps the yard humming.</p>
@@ -107,7 +107,7 @@
       <div id="jamie" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Jamie Patel" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Jamie Patel" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Jamie Patel</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Logistics Coordinator</p>
             <p class="text-sm text-brand-steel">GPS-tracked roll-off ninja.</p>
@@ -120,7 +120,7 @@
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Riley Thompson" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Riley Thompson" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Riley Thompson</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Customer Success Lead</p>
             <p class="text-sm text-brand-steel">Friendly face at the pay-window.</p>
@@ -133,7 +133,7 @@
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Mike 'Sparky' Nguyen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Mike 'Sparky' Nguyen" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Mike “Sparky” Nguyen</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Demolition Foreman</p>
             <p class="text-sm text-brand-steel">Licensed torch cutter. Problem solver.</p>
@@ -146,7 +146,7 @@
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Victoria Chen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Victoria Chen" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Victoria Chen</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Environmental &amp; Compliance</p>
             <p class="text-sm text-brand-steel">Paperwork pro and training lead.</p>


### PR DESCRIPTION
## Summary
- reduce hero grid size to show more cards per row
- shrink each team photo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861beb3e8d8832985b1b2d052341c64