### PR TITLE
Fix padding for How It Works section

### DIFF
--- a/process.html
+++ b/process.html
@@ -137,7 +137,7 @@
     </div>
   </section>
 
-  <section class="pt-20 pb-0 bg-gray-100">
+  <section class="py-20 bg-gray-100">
     <div class="timeline-container max-w-[1024px] mx-auto px-6">
       <h2 class="text-3xl font-bold text-center mb-8">How It Works</h2>
       <ul class="timeline list-none flex flex-col md:flex-row justify-between gap-8 md:gap-14 relative">


### PR DESCRIPTION
## Summary
- restore bottom padding on the How It Works section of the process page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861c3b8b46c8329944b258c1093e78a