### PR TITLE
Fix slick carousel visuals

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -252,11 +252,16 @@ header nav a:hover::after,
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: var(--color-cards);
+  background-color: var(--color-success);
   border: none;
 }
 .slick-dots li.slick-active button {
   background-color: var(--color-links);
+}
+
+/* Ensure carousel cards aren't clipped */
+.values-carousel .slick-list {
+  overflow: visible;
 }
 
 /* Materials accordion arrow animation */


### PR DESCRIPTION
## Summary
- tweak slick dot colors for better contrast
- ensure carousel cards aren't clipped

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861c46540c48329bbbb1971e1f8f68f