### PR TITLE
Restore team card layout

### DIFF
--- a/our-team.html
+++ b/our-team.html
@@ -82,7 +82,7 @@
     <div class="absolute inset-0 -z-10 bg-black/70"></div>
     <div class="mx-auto max-w-3xl px-6 text-white">
       <h1 class="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4">The People Behind the Pay‑Window.</h1>
-      <p class="mb-8">Five specialists, one mission—honest weights, instant pay.</p>
+      <p class="mb-8">Four specialists, one mission—honest weights, instant pay.</p>
       <div class="flex flex-col sm:flex-row justify-center gap-4">
         <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 text-white font-semibold shadow hover:opacity-90 transition">Request a Quote</a>
         <a href="careers.html" class="rounded-md bg-white px-8 py-3 text-brand-orange font-semibold shadow-lg hover:bg-gray-100 transition">Join the Team</a>
@@ -90,11 +90,11 @@
     </div>
   </section>
   <section id="team" class="py-20">
-    <div class="max-w-6xl mx-auto px-6 grid gap-8 team-grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+    <div class="max-w-6xl mx-auto px-6 grid gap-8 team-grid grid-cols-1 md:grid-cols-2">
       <div id="alex" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Alex Martinez" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Alex Martinez" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Alex Martinez</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Operations Manager</p>
             <p class="text-sm text-brand-steel">15‑yr vet, OSHA‑30, keeps the yard humming.</p>
@@ -107,7 +107,7 @@
       <div id="jamie" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Jamie Patel" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Jamie Patel" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Jamie Patel</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Logistics Coordinator</p>
             <p class="text-sm text-brand-steel">GPS-tracked roll-off ninja.</p>
@@ -120,7 +120,7 @@
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Riley Thompson" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Riley Thompson" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Riley Thompson</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Customer Success Lead</p>
             <p class="text-sm text-brand-steel">Friendly face at the pay-window.</p>
@@ -133,20 +133,7 @@
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Mike 'Sparky' Nguyen" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
-            <h3 class="font-semibold text-lg">Mike “Sparky” Nguyen</h3>
-            <p class="text-sm text-brand-steel uppercase mb-2">Demolition Foreman</p>
-            <p class="text-sm text-brand-steel">Licensed torch cutter. Problem solver.</p>
-          </div>
-          <div class="flip-back bg-white rounded-xl text-center text-sm text-brand-steel p-4">
-            <p>Sparky leads our on-site demolition crew tackling everything from refinery pipe to bridge beams. Phone <a href="tel:5552223333" class="text-brand-orange">555‑222‑3333</a>.</p>
-          </div>
-        </div>
-      </div>
-      <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
-        <div class="flip-card-inner aspect-square">
-          <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Victoria Chen" class="w-32 h-32 sm:w-40 sm:h-40 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Victoria Chen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Victoria Chen</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Environmental &amp; Compliance</p>
             <p class="text-sm text-brand-steel">Paperwork pro and training lead.</p>


### PR DESCRIPTION
## Summary
- revert to larger team card images
- switch layout to 2 columns on desktop and 1 on mobile
- remove the Sparky Nguyen card
- update tagline to match team size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861c595a0988329b2b56fb97e218ebc