### PR TITLE
Adjust team card sizing for desktop

### DIFF
--- a/our-team.html
+++ b/our-team.html
@@ -94,7 +94,7 @@
       <div id="alex" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Alex Martinez" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Alex Martinez" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Alex Martinez</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Operations Manager</p>
             <p class="text-sm text-brand-steel">15‑yr vet, OSHA‑30, keeps the yard humming.</p>
@@ -107,7 +107,7 @@
       <div id="jamie" class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Jamie Patel" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Jamie Patel" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Jamie Patel</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Logistics Coordinator</p>
             <p class="text-sm text-brand-steel">GPS-tracked roll-off ninja.</p>
@@ -120,7 +120,7 @@
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Riley Thompson" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Riley Thompson" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Riley Thompson</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Customer Success Lead</p>
             <p class="text-sm text-brand-steel">Friendly face at the pay-window.</p>
@@ -133,7 +133,7 @@
       <div class="flip-card team-card bg-white rounded-xl shadow border border-brand-steel/10 transition-transform hover:-translate-y-1">
         <div class="flip-card-inner aspect-square">
           <div class="flip-front flex flex-col items-center text-center">
-            <img src="assets/hero.jpg" alt="Victoria Chen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-64 lg:h-64 object-cover rounded-lg mb-3">
+            <img src="assets/hero.jpg" alt="Victoria Chen" class="w-40 h-40 sm:w-48 sm:h-48 lg:w-48 lg:h-48 object-cover rounded-lg mb-3">
             <h3 class="font-semibold text-lg">Victoria Chen</h3>
             <p class="text-sm text-brand-steel uppercase mb-2">Environmental &amp; Compliance</p>
             <p class="text-sm text-brand-steel">Paperwork pro and training lead.</p>


### PR DESCRIPTION
## Summary
- shrink team card images on large screens by 25%

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861c78b27d4832989657c35ebcad658