### PR TITLE
Fix broken Our Team carousel

### DIFF
--- a/our-team.html
+++ b/our-team.html
@@ -26,7 +26,6 @@
 <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
 <link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet'>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-<link rel="stylesheet" href="assets/slick.min.css"/>
 <link rel="stylesheet" href="assets/styles.css">
 <meta name="description" content="Meet the dedicated Demo Yard team behind our trusted service.">
 <meta property="og:title" content="Our Team | Demo Yard">
@@ -207,13 +206,6 @@
 </footer>
 <script>
   document.getElementById('year').textContent = new Date().getFullYear();
-</script>
-<script src="assets/jquery-3.6.0.min.js"></script>
-<script src="assets/slick.min.js"></script>
-<script>
-  if (window.jQuery && document.querySelector('.values-carousel')) {
-    $('.values-carousel').slick({ dots: true, arrows: false, autoplay: true, autoplaySpeed: 3000 });
-  }
 </script>
 <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -238,6 +238,46 @@ function initQuoteBar() {
   check();
 }
 
+function initValuesCarousel() {
+  const container = document.querySelector('.values-carousel');
+  if (!container) return;
+  const slides = Array.from(container.children);
+  if (!slides.length) return;
+
+  const dotList = document.createElement('ul');
+  dotList.className = 'slick-dots';
+
+  slides.forEach((slide, idx) => {
+    if (idx !== 0) slide.classList.add('hidden');
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    li.appendChild(btn);
+    dotList.appendChild(li);
+    btn.addEventListener('click', () => show(idx));
+  });
+
+  container.after(dotList);
+
+  let index = 0;
+  const show = (i) => {
+    slides.forEach((s, idx) => s.classList.toggle('hidden', idx !== i));
+    dotList.querySelectorAll('li').forEach((d, idx) => {
+      d.classList.toggle('slick-active', idx === i);
+    });
+  };
+
+  const next = () => {
+    index = (index + 1) % slides.length;
+    show(index);
+  };
+
+  let timer = setInterval(next, 3000);
+  container.addEventListener('mouseenter', () => clearInterval(timer));
+  container.addEventListener('mouseleave', () => { timer = setInterval(next, 3000); });
+
+  show(index);
+}
+
 function initTeamCarousel() {
   const container = document.getElementById('teamCarousel');
   if (!container) return;
@@ -282,6 +322,8 @@ function initPage() {
   initQuoteBar();
 
   initMaterialCards();
+
+  initValuesCarousel();
 
   initTeamCarousel();
 


### PR DESCRIPTION
## Summary
- add a vanilla JS carousel implementation
- remove slick carousel from Our Team page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861c8abb1608329a6e352b3ba00e3ad