### PR TITLE
Add fade animation to values carousel

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -308,3 +308,12 @@ header nav a:hover::after,
   border: none;
   outline: none;
 }
+
+/* Fade-in animation used by carousels */
+@keyframes values-fade-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+.fade-in {
+  animation: values-fade-in 0.5s ease;
+}

--- a/script.js
+++ b/script.js
@@ -260,7 +260,17 @@ function initValuesCarousel() {
 
   let index = 0;
   const show = (i) => {
-    slides.forEach((s, idx) => s.classList.toggle('hidden', idx !== i));
+    slides.forEach((s, idx) => {
+      if (idx === i) {
+        s.classList.remove('hidden');
+        s.classList.add('fade-in');
+        s.addEventListener('animationend', () => {
+          s.classList.remove('fade-in');
+        }, { once: true });
+      } else {
+        s.classList.add('hidden');
+      }
+    });
     dotList.querySelectorAll('li').forEach((d, idx) => {
       d.classList.toggle('slick-active', idx === i);
     });


### PR DESCRIPTION
## Summary
- animate the Values carousel slides with a fade-in effect
- define a reusable `fade-in` animation

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6861cc9801488329af79d207e96f2d39