### PR TITLE
Add asset paths to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@
 This repository contains a static demo website for a fictional scrapyard called **Demo Yard**. Open `index.html` in a browser to explore the landing page and navigate to other pages like Services or Pricing.
 
 All styles and behavior are implemented with Tailwind CSS and small JavaScript helpers in `script.js`.
+
+## Assets
+
+The project stores all images, style sheets and scripts in the `assets/` folder. Asset files referenced by the HTML pages include:
+
+- `assets/banknotes.svg`
+- `assets/clipboard-document-list.svg`
+- `assets/hero.jpg`
+- `assets/jquery-3.6.0.min.js`
+- `assets/logo.png`
+- `assets/logo.svg`
+- `assets/slick.min.css`
+- `assets/slick.min.js`
+- `assets/styles.css`
+- `assets/truck.svg`
+- `assets/yard-map.svg`


### PR DESCRIPTION
## Summary
- document asset file paths referenced by the site

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ccdc3cc08329aa6558d5c0199d34