### PR TITLE
Fix process reminder layout on mobile

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -278,6 +278,7 @@ header nav a:hover::after,
   padding: 1rem;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .timeline-step .icon {


### PR DESCRIPTION
## Summary
- wrap items inside the process-tip flex container to avoid overflow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861ce3d04ec8329a4aa6fed73a140a8