### PR TITLE
Fix team card toggle on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -174,7 +174,11 @@ function initTeamFlip() {
   cards.forEach(card => {
     card.addEventListener('click', () => {
       if (window.matchMedia('(hover: none)').matches) {
-        card.classList.toggle('flipped');
+        const active = card.classList.toggle('flipped');
+        if (!active) {
+          const focused = card.querySelector(':focus');
+          if (focused) focused.blur();
+        }
       }
     });
     card.addEventListener('keyup', (e) => {


### PR DESCRIPTION
## Summary
- ensure Our Team cards unflip on second tap by blurring focused element

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6861ce9bdbbc83299443831afd4ab126