### PR TITLE
Remove quick reminder from Process page

### DIFF
--- a/process.html
+++ b/process.html
@@ -196,14 +196,6 @@
       </ul>
     </div>
   </section>
-  <aside class="process-tip w-full px-6">
-    <svg class="w-5 h-5 text-brand-orange mr-2" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20"><path d="M7.293 14.707a1 1 0 010-1.414L9.586 11H3a1 1 0 110-2h6.586L7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"/></svg>
-    <strong>Quick reminder:</strong>&nbsp;Drain fuel, oil and refrigerants—wet loads can’t be accepted.
-  </aside>
-
-
-
-
 
 <section class="py-20 bg-white">
   <div class="max-w-3xl mx-auto px-6">


### PR DESCRIPTION
## Summary
- remove the "quick reminder" aside from `process.html`

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861d818505483298051bf0a37399042