### PR TITLE
Remove fade-up animation from carousel icons

### DIFF
--- a/our-team.html
+++ b/our-team.html
@@ -183,17 +183,17 @@
       <div class="md:w-5/12">
         <div class="values-carousel">
           <div class="p-6 bg-white rounded-lg border border-brand-steel/10 shadow text-center">
-            <div class="text-brand-orange text-4xl mb-3" data-aos="fade-up" data-aos-delay="0"><i class="fa-regular fa-clock"></i></div>
+            <div class="text-brand-orange text-4xl mb-3"><i class="fa-regular fa-clock"></i></div>
             <p class="font-semibold mb-1">Fast Turnaround</p>
             <p class="text-sm text-brand-steel">Digital tickets and cash before you hit the gate.</p>
           </div>
           <div class="p-6 bg-white rounded-lg border border-brand-steel/10 shadow text-center">
-            <div class="text-brand-orange text-4xl mb-3" data-aos="fade-up" data-aos-delay="80"><i class="fa-solid fa-recycle"></i></div>
+            <div class="text-brand-orange text-4xl mb-3"><i class="fa-solid fa-recycle"></i></div>
             <p class="font-semibold mb-1">Stewardship</p>
             <p class="text-sm text-brand-steel">Storm-water controls and zero-landfill goals.</p>
           </div>
           <div class="p-6 bg-white rounded-lg border border-brand-steel/10 shadow text-center">
-            <div class="text-brand-orange text-4xl mb-3" data-aos="fade-up" data-aos-delay="160"><i class="fa-solid fa-handshake"></i></div>
+            <div class="text-brand-orange text-4xl mb-3"><i class="fa-solid fa-handshake"></i></div>
             <p class="font-semibold mb-1">Partners First</p>
             <p class="text-sm text-brand-steel">Long-term relationships over quick wins.</p>
           </div>


### PR DESCRIPTION
## Summary
- update How We Keep the Yard Running Smoothly carousel
- remove data-aos attributes so icons no longer animate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861d873492c8329946ffcc0a3718514