### PR TITLE
Update materials CTA button

### DIFF
--- a/accepted-materials.html
+++ b/accepted-materials.html
@@ -86,7 +86,7 @@
       <p class="mt-4 text-white text-lg">Top prices for copper, aluminum, steel and more—zero hidden fees.</p>
       <div class="mt-10 flex flex-col sm:flex-row gap-4 hero-cta">
         <a href="contact.html" class="rounded-md bg-brand-orange px-8 py-3 text-white font-semibold shadow hover:opacity-90 transition">Request a Quote</a>
-        <a href="contact.html" class="rounded-md bg-white px-8 py-3 text-brand-orange font-semibold shadow-lg hover:bg-gray-100 transition">Text a Photo</a>
+        <a href="#details" class="rounded-md bg-white px-8 py-3 text-brand-orange font-semibold shadow-lg hover:bg-gray-100 transition flex items-center justify-center gap-2">View Details <i class="fa-solid fa-arrow-down"></i></a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- replace "Text a Photo" button with "View Details" button in Materials page
- use Font Awesome arrow icon and link directly to Details section

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686279ad54a883299bb95ec97feff5b0