### PR TITLE
Update mobile menu background

### DIFF
--- a/about.html
+++ b/about.html
@@ -77,7 +77,7 @@
       </svg>
     </button>
     </div>
-    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+    <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/accepted-materials.html
+++ b/accepted-materials.html
@@ -59,7 +59,7 @@
       </svg>
     </button>
     </div>
-    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+    <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/contact.html
+++ b/contact.html
@@ -77,7 +77,7 @@
       </svg>
     </button>
     </div>
-    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+    <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/faq.html
+++ b/faq.html
@@ -78,7 +78,7 @@
       </svg>
     </button>
     </div>
-    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+    <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
       </svg>
     </button>
     </div>
-    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+    <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/our-team.html
+++ b/our-team.html
@@ -59,7 +59,7 @@
       </svg>
     </button>
     </div>
-    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+    <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/pricing.html
+++ b/pricing.html
@@ -77,7 +77,7 @@
       </svg>
     </button>
     </div>
-    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+    <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/process.html
+++ b/process.html
@@ -78,7 +78,7 @@
       </svg>
     </button>
     </div>
-    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+    <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/services.html
+++ b/services.html
@@ -79,7 +79,7 @@
       </svg>
     </button>
     </div>
-    <div id="mobileMenu" class="fixed inset-0 bg-gray-900 bg-opacity-95 z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+    <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>


### PR DESCRIPTION
## Summary
- change mobile menu background from dark overlay to white across all pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68627b4405948329ba2fa8d6c9aa9bfe