### PR TITLE
Fix mobile menu close icon color

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -99,6 +99,11 @@ header {
   color: var(--color-headlines) !important;
 }
 
+/* Ensure close icon is visible on white background */
+#closeMenu {
+  color: var(--color-headlines) !important;
+}
+
 /* Nav bar underline animation */
 header nav a,
 #mobileMenu a:not(.bg-yellow-500) {


### PR DESCRIPTION
## Summary
- ensure the close icon in the mobile menu uses the site's text color so it's visible on the white background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865a8e22cb883298d86256374e279f1