### PR TITLE
Update base tier name in pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -104,9 +104,9 @@
     </p>
 
     <div class="mt-14 grid gap-10 md:grid-cols-3">
-      <!-- Launch -->
+      <!-- Standard Launch -->
       <div class="relative bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
-        <h3 class="text-xl font-semibold mb-4">Launch Package</h3>
+        <h3 class="text-xl font-semibold mb-4">Standard Launch</h3>
         <p class="text-5xl font-extrabold tracking-tight">$2,499</p>
         <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
           <li>• One scrolling page, built mobile-first</li>


### PR DESCRIPTION
## Summary
- rename the Launch Package tier to Standard Launch on the pricing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868314e16288329aa4ed0a9f60ce63e