### PR TITLE
Adjust hero overlay and social banner colors

### DIFF
--- a/about.html
+++ b/about.html
@@ -98,7 +98,7 @@
   <!-- Hero / Mission Banner -->
   <section id="mission" class="relative isolate min-h-[calc(100vh-4rem)] flex items-center">
     <div class="absolute inset-0 -z-10 bg-[url('assets/hero.jpg')] bg-cover bg-center brightness-[.55]"></div>
-    <div class="absolute inset-0 -z-10 bg-gray-700/70"></div>
+    <div class="absolute inset-0 -z-10 bg-black/70"></div>
     <div class="max-w-4xl mx-auto px-6 text-center md:text-left">
       <h1 class="text-4xl sm:text-5xl md:text-6xl font-extrabold text-white drop-shadow-lg">
         Built on Metal, Powered by Integrity

--- a/accepted-materials.html
+++ b/accepted-materials.html
@@ -80,7 +80,7 @@
   <!-- Hero -->
   <section id="top" class="scroll-mt-16 relative isolate flex items-center justify-center text-center min-h-[calc(100vh-4rem)]">
     <div class="absolute inset-0 -z-10 bg-[url('assets/hero.jpg')] bg-cover bg-center brightness-[.55]"></div>
-    <div class="absolute inset-0 -z-10 bg-gray-700/70"></div>
+    <div class="absolute inset-0 -z-10 bg-black/70"></div>
     <div class="flex flex-col items-center justify-center w-full h-full px-6">
       <h1 class="font-extrabold text-white leading-tight" style="font-size:clamp(40px,7vw,56px)">Accepted Materials</h1>
       <p class="mt-4 text-white text-lg">Top prices for copper, aluminum, steel and more—zero hidden fees.</p>

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
          class="scroll-mt-16 pt-16 relative isolate min-h-[calc(100vh-4rem)] flex items-center justify-center text-center">
   <!-- Background -->
   <div class="absolute inset-0 -z-10 bg-[url('assets/hero.jpg')] bg-cover bg-center brightness-[.55]"></div>
-  <div class="absolute inset-0 -z-10 bg-gray-700/70"></div>
+  <div class="absolute inset-0 -z-10 bg-black/70"></div>
 
   <div class="mx-auto max-w-3xl px-6">
     <h1 class="text-4xl sm:text-5xl md:text-6xl font-extrabold leading-tight text-white drop-shadow-lg">
@@ -172,7 +172,7 @@
 </section>
 
 <!-- Rating/Client Logos Band -->
-<section id="client-band" class="bg-brand-charcoal text-white py-8 relative overflow-hidden">
+<section id="client-band" class="bg-brand-steel text-white py-8 relative overflow-hidden">
   <div class="max-w-7xl mx-auto px-6 flex flex-wrap justify-center items-center gap-6 text-sm">
     <div class="flex items-center gap-2 whitespace-nowrap">
       <span class="text-yellow-400">★★★★★</span>

--- a/our-team.html
+++ b/our-team.html
@@ -78,7 +78,7 @@
 <main class="flex-grow">
   <section id="team-hero" class="relative flex items-center justify-center text-center min-h-[calc(100vh-4rem)]">
     <div class="absolute inset-0 -z-10 bg-[url('assets/hero.jpg')] bg-cover bg-center brightness-[.55]"></div>
-    <div class="absolute inset-0 -z-10 bg-gray-700/70"></div>
+    <div class="absolute inset-0 -z-10 bg-black/70"></div>
     <div class="mx-auto max-w-3xl px-6 text-white">
       <h1 class="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4">The People Behind the Pay‑Window.</h1>
       <p class="mb-8">Four specialists, one mission—honest weights, instant pay.</p>

--- a/process.html
+++ b/process.html
@@ -99,7 +99,7 @@
 
 <section id="hero" class="relative isolate flex items-center justify-center text-center min-h-[calc(100vh-4rem)]">
   <div class="absolute inset-0 -z-10 bg-[url('assets/hero.jpg')] bg-cover bg-center brightness-[.55]"></div>
-  <div class="absolute inset-0 -z-10 bg-gray-700/70"></div>
+  <div class="absolute inset-0 -z-10 bg-black/70"></div>
   <div class="relative z-10 max-w-2xl px-6">
     <h1 class="font-extrabold text-white text-[clamp(38px,7vw,56px)]">From Pull-Up to Payout in 3 Easy Steps</h1>
     <p class="mt-4 text-lg text-white">Average yard time: 10&nbsp;minutes — no appointment needed.</p>

--- a/services.html
+++ b/services.html
@@ -101,7 +101,7 @@
 <!-- Hero -->
 <section id="top" class="scroll-mt-16 relative isolate flex items-center justify-center text-center text-white min-h-[calc(100vh-4rem)]">
   <div class="absolute inset-0 -z-10 bg-[url('assets/hero.jpg')] bg-cover bg-center brightness-[.55]"></div>
-  <div class="absolute inset-0 -z-10 bg-gray-700/70"></div>
+  <div class="absolute inset-0 -z-10 bg-black/70"></div>
   <div class="flex flex-col items-center justify-center w-full h-full px-6">
     <h1 class="text-[7vw] md:text-6xl font-extrabold">Five Ways We Turn Scrap Into Cash.</h1>
     <p class="mt-4 text-lg md:text-xl">Choose the option that fits your haul, schedule, and job-site.</p>


### PR DESCRIPTION
## Summary
- revert hero overlays to black across pages
- set social proof banner background to grey

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68685e7173f88329a61394c4325772ba