### PR TITLE
Remove rolloff image overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,10 +281,8 @@
       </div>
     </div>
     <div class="space-y-4">
-      <div class="md:hidden relative rounded-lg overflow-hidden shadow">
+      <div class="md:hidden rounded-lg overflow-hidden shadow">
         <img src="assets/rolloff.jpg" alt="Roll-off being winched" class="w-full object-cover">
-        <div class="absolute inset-0 bg-black/60"></div>
-        <span class="absolute bottom-2 right-2 text-xs text-white bg-black/60 px-2 rounded">Tap to enlarge</span>
       </div>
       <div class="hidden md:block relative overflow-hidden rounded-lg shadow group">
         <div class="flex w-[300%] transition-transform duration-700 group-hover:-translate-x-1/3">


### PR DESCRIPTION
## Summary
- remove dark overlay and 'tap to enlarge' text on mobile rolloff image

## Testing
- `grep -n "rolloff.jpg" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_687438ac74b48329af8aa81151d307dc