### PR TITLE
Add about page image references

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The project stores all images, style sheets and scripts in the `assets/` folder.
 - `assets/logo.svg`
 - `assets/truck.svg`
 - `assets/yard-map.svg`
+- `assets/about-hero.jpg`
+- `assets/about-photo1.jpg`
+- `assets/about-photo2.jpg`
+- `assets/about-photo3.jpg`
+- `assets/about-photo4.jpg`
+- `assets/about-photo5.jpg`
 
 Other referenced assets include:
 

--- a/about.html
+++ b/about.html
@@ -32,7 +32,7 @@
 <meta property="og:description" content="Learn about Demo Yard's commitment to fair pricing, quick turnarounds, and exceptional service.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.demoyard.com/about.html">
-<meta property="og:image" content="https://www.demoyard.com/assets/hero.jpg">
+<meta property="og:image" content="https://www.demoyard.com/assets/about-hero.jpg">
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg" sizes="any"/>
   <link rel="icon" type="image/png" href="assets/logo.png"/>
   <link rel="mask-icon" href="assets/logo.svg" color="#D75E02"/>
@@ -97,7 +97,7 @@
 <main class="flex-grow">
   <!-- Hero / Mission Banner -->
   <section id="mission" class="relative isolate min-h-[calc(100vh-4rem)] flex items-center">
-    <div class="absolute inset-0 -z-10 bg-[url('assets/hero.jpg')] bg-cover bg-center brightness-[.55]"></div>
+    <div class="absolute inset-0 -z-10 bg-[url('assets/about-hero.jpg')] bg-cover bg-center brightness-[.55]"></div>
     <div class="absolute inset-0 -z-10 bg-black/70"></div>
     <div class="max-w-4xl mx-auto px-6 text-center md:text-left">
       <h1 class="text-4xl sm:text-5xl md:text-6xl font-extrabold text-white drop-shadow-lg">
@@ -209,11 +209,11 @@
         </div>
       </div>
       <div class="grid grid-cols-3 grid-rows-2 gap-4 order-1 md:order-2">
-        <img src="assets/hero.jpg" class="w-full h-full object-cover rounded-lg row-span-2" alt="Team member"/>
-        <img src="assets/hero.jpg" class="w-full h-full object-cover rounded-lg" alt="Team member"/>
-        <img src="assets/hero.jpg" class="w-full h-full object-cover rounded-lg" alt="Team member"/>
-        <img src="assets/hero.jpg" class="w-full h-full object-cover rounded-lg" alt="Loader"/>
-        <img src="assets/hero.jpg" class="w-full h-full object-cover rounded-lg" alt="Team member"/>
+        <img src="assets/about-photo1.jpg" class="w-full h-full object-cover rounded-lg row-span-2" alt="Team member"/>
+        <img src="assets/about-photo2.jpg" class="w-full h-full object-cover rounded-lg" alt="Team member"/>
+        <img src="assets/about-photo3.jpg" class="w-full h-full object-cover rounded-lg" alt="Team member"/>
+        <img src="assets/about-photo4.jpg" class="w-full h-full object-cover rounded-lg" alt="Loader"/>
+        <img src="assets/about-photo5.jpg" class="w-full h-full object-cover rounded-lg" alt="Team member"/>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- reference a new hero image for the About page
- add placeholders for five spotlight photos
- document the new images in the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68743d251fe88329b3da85c49c120101