### PR TITLE
Apply example nav styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -61,13 +61,13 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">
-      <span class="text-xl md:text-2xl font-black tracking-tight animated-link">
+      <span class="site-title text-xl md:text-2xl font-black tracking-tight">
         <span class="text-brand-orange">Premium</span>
         <span class="text-brand-charcoal">Demo</span>
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-yellow-400">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-brand-orange">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -84,13 +84,13 @@
         </svg>
       </button>
       
-      <a href="services.html" class="hover:text-yellow-400">Services</a>
-      <a href="process.html" class="hover:text-yellow-400">Process</a>
-      <a href="accepted-materials.html" class="hover:text-yellow-400">Materials</a>
-      
-      <a href="about.html" class="text-yellow-400 hover:text-yellow-400">About Us</a>
-      <a href="our-team.html" class="hover:text-yellow-400">Our Team</a>
-      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="services.html">Services</a>
+      <a href="process.html">Process</a>
+      <a href="accepted-materials.html">Materials</a>
+
+      <a href="about.html" class="text-brand-orange">About Us</a>
+      <a href="our-team.html">Our Team</a>
+      <a href="faq.html">FAQ</a>
       <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
     </div>
   </header>

--- a/accepted-materials.html
+++ b/accepted-materials.html
@@ -43,13 +43,13 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">
-      <span class="text-xl md:text-2xl font-black tracking-tight animated-link">
+      <span class="site-title text-xl md:text-2xl font-black tracking-tight">
         <span class="text-brand-orange">Premium</span>
         <span class="text-brand-charcoal">Demo</span>
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-yellow-400">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-brand-orange">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -66,13 +66,13 @@
         </svg>
       </button>
 
-      <a href="services.html" class="hover:text-yellow-400">Services</a>
-      <a href="process.html" class="hover:text-yellow-400">Process</a>
-      <a href="accepted-materials.html" class="text-yellow-400 hover:text-yellow-400">Materials</a>
-      
-      <a href="about.html" class="hover:text-yellow-400">About Us</a>
-      <a href="our-team.html" class="hover:text-yellow-400">Our Team</a>
-      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="services.html">Services</a>
+      <a href="process.html">Process</a>
+      <a href="accepted-materials.html" class="text-brand-orange">Materials</a>
+
+      <a href="about.html">About Us</a>
+      <a href="our-team.html">Our Team</a>
+      <a href="faq.html">FAQ</a>
       <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
     </div>
   </header>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -104,56 +104,62 @@ header {
   color: var(--color-headlines) !important;
 }
 
+/* Default charcoal text for navigation links */
+header nav a {
+  color: #2b2b2b;
+  line-height: 1;
+}
+
+/* Highlight active link in the desktop nav */
+header nav a.text-brand-orange {
+  color: var(--color-links);
+}
+
+/* Ensure active link highlights in the mobile menu */
+#mobileMenu a.text-brand-orange {
+  color: #d75e02;
+}
+
 /* Nav bar underline animation */
 header nav a,
-#mobileMenu a:not(.bg-yellow-500) {
+#mobileMenu a:not(.bg-yellow-500):not(.btn-primary) {
   position: relative;
   text-decoration: none;
 }
 
 header nav a:hover,
-#mobileMenu a:not(.bg-yellow-500):hover {
+#mobileMenu a:not(.bg-yellow-500):not(.btn-primary):hover {
   color: currentColor !important; /* keep existing color on hover */
 }
 /* Keep active nav item orange even when hovered */
-header nav a.text-yellow-400:hover {
+header nav a.text-brand-orange:hover {
   color: var(--color-links) !important;
 }
 
-/* Reusable animated link style */
-.animated-link {
+/* Brand title underline animation */
+.site-title {
   position: relative;
-  text-decoration: none;
+  display: inline-block;
   font-weight: bold;
 }
 
-.animated-link:hover {
-  color: currentColor !important;
-}
-
-.animated-link::after {
+.site-title::after {
   content: '';
   position: absolute;
   left: 0;
   bottom: -2px;
-  width: 100%;
+  width: 0;
   height: 2px;
   background-color: var(--color-links);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.3s ease;
+  transition: width 0.3s ease;
 }
 
-.animated-link:hover::after {
-  transform: scaleX(1);
+a:hover .site-title::after {
+  width: 100%;
 }
 
-/* Hovering over the entire home button also triggers the underline */
-#homeButton:hover .animated-link::after {
-  transform: scaleX(1);
-}
-#homeButton:hover .animated-link {
-  color: currentColor !important;
+#homeButton:hover .site-title::after {
+  width: 100%;
 }
 
 header nav a::after,
@@ -176,8 +182,8 @@ header nav a:hover::after,
 /* Remove underline animations on narrow screens */
 @media (max-width: 767px) {
   header nav a::after,
-  #mobileMenu a:not(.bg-yellow-500)::after,
-  .animated-link::after {
+  #mobileMenu a:not(.bg-yellow-500):not(.btn-primary)::after,
+  .site-title::after {
     display: none;
   }
 }

--- a/contact.html
+++ b/contact.html
@@ -61,13 +61,13 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">
-      <span class="text-xl md:text-2xl font-black tracking-tight animated-link">
+      <span class="site-title text-xl md:text-2xl font-black tracking-tight">
         <span class="text-brand-orange">Premium</span>
         <span class="text-brand-charcoal">Demo</span>
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-yellow-400">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-brand-orange">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -84,13 +84,13 @@
         </svg>
       </button>
       
-      <a href="services.html" class="hover:text-yellow-400">Services</a>
-      <a href="process.html" class="hover:text-yellow-400">Process</a>
-      <a href="accepted-materials.html" class="hover:text-yellow-400">Materials</a>
-      
-      <a href="about.html" class="hover:text-yellow-400">About Us</a>
-      <a href="our-team.html" class="hover:text-yellow-400">Our Team</a>
-      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="services.html">Services</a>
+      <a href="process.html">Process</a>
+      <a href="accepted-materials.html">Materials</a>
+
+      <a href="about.html">About Us</a>
+      <a href="our-team.html">Our Team</a>
+      <a href="faq.html">FAQ</a>
       <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
     </div>
   </header>

--- a/faq.html
+++ b/faq.html
@@ -62,13 +62,13 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">
-      <span class="text-xl md:text-2xl font-black tracking-tight animated-link">
+      <span class="site-title text-xl md:text-2xl font-black tracking-tight">
         <span class="text-brand-orange">Premium</span>
         <span class="text-brand-charcoal">Demo</span>
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-yellow-400">FAQ</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-brand-orange">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -85,13 +85,13 @@
         </svg>
       </button>
       
-      <a href="services.html" class="hover:text-yellow-400">Services</a>
-      <a href="process.html" class="hover:text-yellow-400">Process</a>
-      <a href="accepted-materials.html" class="hover:text-yellow-400">Materials</a>
-      
-      <a href="about.html" class="hover:text-yellow-400">About Us</a>
-      <a href="our-team.html" class="hover:text-yellow-400">Our Team</a>
-      <a href="faq.html" class="text-yellow-400 hover:text-yellow-400">FAQ</a>
+      <a href="services.html">Services</a>
+      <a href="process.html">Process</a>
+      <a href="accepted-materials.html">Materials</a>
+
+      <a href="about.html">About Us</a>
+      <a href="our-team.html">Our Team</a>
+      <a href="faq.html" class="text-brand-orange">FAQ</a>
       <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
     </div>
   </header>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">
-      <span class="text-xl md:text-2xl font-black tracking-tight animated-link">
+      <span class="site-title text-xl md:text-2xl font-black tracking-tight">
         <span class="text-brand-orange">Premium</span>
         <span class="text-brand-charcoal">Demo</span>
       </span>
@@ -85,13 +85,13 @@
         </svg>
       </button>
       
-      <a href="services.html" class="hover:text-yellow-400">Services</a>
-      <a href="process.html" class="hover:text-yellow-400">Process</a>
-      <a href="accepted-materials.html" class="hover:text-yellow-400">Materials</a>
-      
-      <a href="about.html" class="hover:text-yellow-400">About Us</a>
-      <a href="our-team.html" class="hover:text-yellow-400">Our Team</a>
-      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="services.html">Services</a>
+      <a href="process.html">Process</a>
+      <a href="accepted-materials.html">Materials</a>
+
+      <a href="about.html">About Us</a>
+      <a href="our-team.html">Our Team</a>
+      <a href="faq.html">FAQ</a>
       <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
     </div>
   </header>

--- a/our-team.html
+++ b/our-team.html
@@ -43,13 +43,13 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">
-      <span class="text-xl md:text-2xl font-black tracking-tight animated-link">
+      <span class="site-title text-xl md:text-2xl font-black tracking-tight">
         <span class="text-brand-orange">Premium</span>
         <span class="text-brand-charcoal">Demo</span>
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-yellow-400">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-brand-orange">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -65,13 +65,13 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
       </button>
-      <a href="services.html" class="hover:text-yellow-400">Services</a>
-      <a href="process.html" class="hover:text-yellow-400">Process</a>
-      <a href="accepted-materials.html" class="hover:text-yellow-400">Materials</a>
-      
-      <a href="about.html" class="hover:text-yellow-400">About Us</a>
-      <a href="our-team.html" class="text-yellow-400 hover:text-yellow-400">Our Team</a>
-      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="services.html">Services</a>
+      <a href="process.html">Process</a>
+      <a href="accepted-materials.html">Materials</a>
+
+      <a href="about.html">About Us</a>
+      <a href="our-team.html" class="text-brand-orange">Our Team</a>
+      <a href="faq.html">FAQ</a>
       <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
     </div>
 </header>

--- a/process.html
+++ b/process.html
@@ -62,13 +62,13 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">
-      <span class="text-xl md:text-2xl font-black tracking-tight animated-link">
+      <span class="site-title text-xl md:text-2xl font-black tracking-tight">
         <span class="text-brand-orange">Premium</span>
         <span class="text-brand-charcoal">Demo</span>
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-yellow-400">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
+      <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-brand-orange">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -85,13 +85,13 @@
         </svg>
       </button>
       
-      <a href="services.html" class="hover:text-yellow-400">Services</a>
-      <a href="process.html" class="text-yellow-400 hover:text-yellow-400">Process</a>
-      <a href="accepted-materials.html" class="hover:text-yellow-400">Materials</a>
-      
-      <a href="about.html" class="hover:text-yellow-400">About Us</a>
-      <a href="our-team.html" class="hover:text-yellow-400">Our Team</a>
-      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="services.html">Services</a>
+      <a href="process.html" class="text-brand-orange">Process</a>
+      <a href="accepted-materials.html">Materials</a>
+
+      <a href="about.html">About Us</a>
+      <a href="our-team.html">Our Team</a>
+      <a href="faq.html">FAQ</a>
       <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
     </div>
 </header>

--- a/services.html
+++ b/services.html
@@ -63,13 +63,13 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">
-      <span class="text-xl md:text-2xl font-black tracking-tight animated-link">
+      <span class="site-title text-xl md:text-2xl font-black tracking-tight">
         <span class="text-brand-orange">Premium</span>
         <span class="text-brand-charcoal">Demo</span>
       </span>
     </a>
     <nav class="hidden md:flex flex-1 justify-center space-x-6">
-      <a href="services.html" class="text-sm font-medium text-yellow-400">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
+      <a href="services.html" class="text-sm font-medium text-brand-orange">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
     <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
@@ -86,13 +86,13 @@
         </svg>
       </button>
 
-      <a href="services.html" class="text-yellow-400 hover:text-yellow-400">Services</a>
-      <a href="process.html" class="hover:text-yellow-400">Process</a>
-      <a href="accepted-materials.html" class="hover:text-yellow-400">Materials</a>
-      
-      <a href="about.html" class="hover:text-yellow-400">About Us</a>
-      <a href="our-team.html" class="hover:text-yellow-400">Our Team</a>
-      <a href="faq.html" class="hover:text-yellow-400">FAQ</a>
+      <a href="services.html" class="text-brand-orange">Services</a>
+      <a href="process.html">Process</a>
+      <a href="accepted-materials.html">Materials</a>
+
+      <a href="about.html">About Us</a>
+      <a href="our-team.html">Our Team</a>
+      <a href="faq.html">FAQ</a>
       <a href="contact.html" class="inline-block rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Request a Quote</a>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- update navigation styling and add brand underline
- adjust mobile menu link classes
- highlight active links using `text-brand-orange`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886b512b64c8329ba418f4da788e3aa